### PR TITLE
Acknowledgements have been moved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,3 @@ Translations for https://peeringdb.com/
 [![Translation status](https://translate.peeringdb.com/widgets/peeringdb/-/287x66-white.png)](https://translate.peeringdb.com/engage/peeringdb/?utm_source=widget)
 
 Documentation is at <https://docs.peeringdb.com/translation/>.
-
-## Thanks to the translators!
-
-- pt
-  - Robert Philips (NTT Communications)
-  - Ligio Gomes (NTT Communications)


### PR DESCRIPTION
Now at https://docs.peeringdb.com/translation/ .