### PR TITLE
Adding/fixing pt_BR translation

### DIFF
--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2023-06-15 11:25+0000\n"
 "PO-Revision-Date: 2023-06-15 13:11+0200\n"
 "Last-Translator: Chris Caputo <ccaputo@alt.net>\n"
 "Language-Team: Portuguese <https://translate.peeringdb.com/projects/peeringdb/server/pt/>\n"
@@ -18,1882 +18,1839 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Poedit 3.3.1\n"
 
-msgid "Ethernet"
-msgstr "Ethernet"
-
-msgid "ATM"
-msgstr "ATM"
-
-msgid "Multiple"
-msgstr "Múltiplo"
-
-msgid "Abuse"
-msgstr "Abuso"
-
-msgid "Maintenance"
-msgstr "Manutenção"
-
-msgid "Policy"
-msgstr "Política"
-
-msgid "Technical"
-msgstr "Técnico"
-
-msgid "NOC"
-msgstr "NOC"
-
-msgid "Public Relations"
-msgstr "Relações públicas"
-
-msgid "Sales"
-msgstr "Vendas"
-
-msgid "Open"
-msgstr "Aberto"
-
-msgid "Selective"
-msgstr "Seletivo"
-
-msgid "Restrictive"
-msgstr "Restritivo"
-
-msgid "No"
-msgstr "Não"
-
-msgid "Not Required"
-msgstr "Opcional"
-
-msgid "Preferred"
-msgstr "Preferido"
-
-msgid "Required - US"
-msgstr "Obrigatória - US"
-
-msgid "Required - EU"
-msgstr "Obrigatório - UE"
-
-msgid "Required - International"
-msgstr "Obrigatório - internacional"
-
-msgid "Private Only"
-msgstr "Apenas Privado"
-
-msgid "Required"
-msgstr "Obrigatório"
-
-msgid "IPv4"
-msgstr "IPv4"
-
-msgid "IPv6"
-msgstr "IPv6"
-
-msgid "Not Disclosed"
-msgstr "Não divulgado"
-
-msgid "Heavy Outbound"
-msgstr "Outbound Pesado"
-
-msgid "Mostly Outbound"
-msgstr "Principalmente de Saída"
-
-msgid "Balanced"
-msgstr "Balanceado"
-
-msgid "Mostly Inbound"
-msgstr "Principalmente Inound"
-
-msgid "Heavy Inbound"
-msgstr "Inbound Pesado"
-
-msgid "North America"
-msgstr "América do Norte"
-
-msgid "Asia Pacific"
-msgstr "Ásia-Pacífico"
-
-msgid "Europe"
-msgstr "Europa"
-
-msgid "South America"
-msgstr "América do Sul"
-
-msgid "Africa"
-msgstr "África"
-
-msgid "Australia"
-msgstr "Austrália"
-
-msgid "Middle East"
-msgstr "Oriente Médio"
-
-msgid "Regional"
-msgstr "Regional"
-
-msgid "Global"
-msgstr "Global"
-
-msgid "0-20Mbps"
-msgstr "0-20Mbps"
-
-msgid "20-100Mbps"
-msgstr "20-100Mbps"
-
-msgid "100-1000Mbps"
-msgstr "100-1000Mbps"
-
-msgid "1-5Gbps"
-msgstr "1-5Gbps"
-
-msgid "5-10Gbps"
-msgstr "5-10Gbps"
-
-msgid "10-20Gbps"
-msgstr "10-20Gbps"
-
-msgid "20-50Gbps"
-msgstr "20-50Gbps"
-
-msgid "50-100Gbps"
-msgstr "50-100Gbps"
-
-msgid "100-200Gbps"
-msgstr "100-200Gbps"
-
-msgid "200-300Gbps"
-msgstr "200-300Gbps"
-
-msgid "300-500Gbps"
-msgstr "300-500Gbps"
-
-msgid "500-1000Gbps"
-msgstr "500-1000Gbps"
-
-msgid "1-5Tbps"
-msgstr "1-5Tbps"
-
-msgid "5-10Tbps"
-msgstr "5-10Tbps"
-
-msgid "10-20Tbps"
-msgstr "10-20Tbps"
-
-msgid "20-50Tbps"
-msgstr "20-50Tbps"
-
-msgid "50-100Tbps"
-msgstr "50-100Tbps"
-
-msgid "100+Tbps"
-msgstr "100+Tbps"
-
-msgid "NSP"
-msgstr "Fornecedor de Serviços de Rede"
-
-msgid "Content"
-msgstr "Conteúdo"
-
-msgid "Cable/DSL/ISP"
-msgstr "Cabo / DSL / ISP"
-
-msgid "Enterprise"
-msgstr "Corporativo"
-
-msgid "Educational/Research"
-msgstr "Educacional/Investigação"
-
-msgid "Non-Profit"
-msgstr "Sem fins lucrativos"
-
-msgid "Route Server"
-msgstr "Servidor de rotas"
-
-msgid "Network Services"
-msgstr "Serviços de rede"
-
-msgid "Route Collector"
-msgstr "Coletor de rotas"
-
-msgid "Private"
-msgstr "Privado"
-
-msgid "Users"
-msgstr "Usuários/Utilizadores"
-
-msgid "Public"
-msgstr "Público"
-
-msgid "An E.164-formatted phone number starts with a +, followed by the country code, then the national phone number (dropping the leading 0 in most countries), without spaces or dashes between the groups of digits"
-msgstr "Um número de telefone no formato E.164 começa com um +, seguido pelo código do país e, em seguida, pelo número de telefone nacional (retirando o 0 inicial na maioria dos países), sem espaços ou hífens entre os grupos de dígitos"
-
-msgid "Best Effort (no SLA)"
-msgstr "Melhor esforço (sem SLA)"
-
-msgid "Normal Business Hours"
-msgstr "Horário comercial normal"
-
-msgid "24/7 Support"
-msgstr "Suporte 24/7"
-
-msgid "No Commercial Terms"
-msgstr "Sem termos comerciais"
-
-msgid "Bundled With Other Services"
-msgstr "Pacote com outros serviços"
-
-msgid "Non-recurring Fees Only"
-msgstr "Somente taxas não recorrentes"
-
-msgid "Recurring Fees"
-msgstr "Taxas recorrentes"
-
-msgid "Owner"
-msgstr "Proprietário"
-
-msgid "Lessee"
-msgstr "Arrendatário"
-
-msgid "48 VDC"
-msgstr "48 VDC"
-
-msgid "120 VAC"
-msgstr "120 VAC"
-
-msgid "208 VAC"
-msgstr "208 VAC"
-
-msgid "240 VAC"
-msgstr "240 VAC"
-
-msgid "480 VAC"
-msgstr "480 VAC"
-
-msgid "Website"
-msgstr "Website"
-
-msgid "Facebook"
-msgstr "Facebook"
-
-msgid "Twitter"
-msgstr "Twitter"
-
-msgid "Instagram"
-msgstr "Instagram"
-
-msgid "LinkedIn"
-msgstr "LinkedIn"
-
-msgid "TikTok"
-msgstr "TikTok"
-
+#: mainsite/settings/__init__.py:1014
 msgid "Kosovo"
 msgstr "Kosovo"
 
-msgid "Invalid value: {}"
-msgstr "Valor inválido: {}"
-
-msgid "Address 1"
-msgstr "Endereço 1"
-
-msgid "Address 2"
-msgstr "Endereço 2"
-
-msgid "City"
-msgstr "Cidade"
-
-msgid "State"
-msgstr "Estado"
-
-msgid "Zip-Code"
-msgstr "Código postal"
-
-msgid "Country"
-msgstr "País"
-
-msgid "Suite"
-msgstr "Sala"
-
-msgid "Floor"
-msgstr "Andar"
-
-msgid "Latitude"
-msgstr "Latitude"
-
-msgid "Longitude"
-msgstr "Longitude"
-
-msgid "Name"
-msgstr "Nome"
-
-msgid "Also Known As"
-msgstr "Também conhecido como"
-
-msgid "Long Name"
-msgstr "Nome Completo"
-
-msgid "Social Media"
-msgstr "Mídia social"
-
-msgid "Notes"
-msgstr "Notas"
-
-msgid "Organization"
-msgstr "Organização"
-
-msgid "Organizations"
-msgstr "Organizações"
-
-msgid "CLLI Code"
-msgstr "Código CLLI"
-
-msgid "Rencode"
-msgstr "Recodificar"
-
-msgid "NPA-NXX"
-msgstr "NPA-NXX"
-
-msgid "Technical Email"
-msgstr "Email técnico"
-
-msgid "Technical Phone"
-msgstr "Telefone Técnico"
-
-msgid "Sales Email"
-msgstr "E-mail de Vendas"
-
-msgid "Sales Phone"
-msgstr "Telefone de Vendas"
-
-msgid "Property"
-msgstr "Propriedade"
-
-msgid "A property owner is the individual or entity that has title to the property. A lessee is a user of a property who has a lease, an agreement, with the owner of the property."
-msgstr "Proprietário é o indivíduo ou entidade que possui o título da propriedade. Um arrendatário é um usuário de uma propriedade que tem um contrato de arrendamento, um acordo, com o proprietário da propriedade."
-
-msgid "Diverse Serving Substations"
-msgstr "Subestações de serviços diversos"
-
-msgid "Two separate and distinct paths to individual substations which should maintain a separated path back to one or more utility generator stations."
-msgstr "A tensão de corrente alternada disponível para os usuários da instalação, diretamente do proprietário ou fornecida separadamente pela concessionária."
-
-msgid "Available Voltage Services"
-msgstr "Serviços de tensão disponíveis"
-
-msgid "The alternating current voltage available to users of the facility either directly from the landlord or delivered by the utility separately."
-msgstr "A tensão de corrente alternada disponível para os usuários da instalação, diretamente do proprietário ou fornecida separadamente pela concessionária."
-
-msgid "Continental Region"
-msgstr "Região continental"
-
-msgid "Status Dashboard"
-msgstr "Painel de status"
-
-msgid "Facility"
-msgstr "PoP"
-
-msgid "Facilities"
-msgstr "PoPs"
-
-msgid "Role"
-msgstr "Função"
-
-msgid "Visibility"
-msgstr "Visibilidade"
-
-msgid "Phone"
-msgstr "Telefone"
-
-msgid "Email"
-msgstr "Email"
-
-msgid "URL"
-msgstr "URL"
-
-msgid "Contact"
-msgstr "Contato"
-
-msgid "Contacts"
-msgstr "Contatos"
-
-msgid "IRR as-set/route-set"
-msgstr "IRR as-set/route-set"
-
-msgid "Reference to an AS-SET or ROUTE-SET in Internet Routing Registry (IRR)"
-msgstr "Referência a um AS-SET ou ROUTE-SET no Internet Routing Registry (IRR)"
-
-msgid "Looking Glass URL"
-msgstr "URL do Looking Glass"
-
-msgid "Route Server URL"
-msgstr "URL do Servidor de rotas"
-
-msgid "Private notes"
-msgstr "Notas Privadas"
-
-msgid "Traffic Levels"
-msgstr "Níveis de tráfego"
-
-msgid "Traffic Ratios"
-msgstr "Proporções de tráfego"
-
-msgid "Geographic Scope"
-msgstr "Alcance geográfico"
-
-msgid "Network Type"
-msgstr "Tipo de rede"
-
-msgid "IPv4 Prefixes"
-msgstr "Prefixos IPv4"
-
-msgid "Recommended maximum number of IPv4 routes/prefixes to be configured on peering sessions for this ASN"
-msgstr "Número máximo recomendado de rotas/prefixos IPv4 a serem configurados em sessões de peering para este ASN"
-
-msgid "IPv6 Prefixes"
-msgstr "Prefixos IPv6"
-
-msgid "Recommended maximum number of IPv6 routes/prefixes to be configured on peering sessions for this ASN"
-msgstr "Número máximo recomendado de rotas/prefixos IPv6 a serem configurados em sessões de peering para este ASN"
-
-msgid "Unicast IPv4"
-msgstr "Unicast IPv4"
-
-msgid "Multicast"
-msgstr "Multicast"
-
-msgid "Unicast IPv6"
-msgstr "Unicast IPv6"
-
-msgid "Never via route servers"
-msgstr "Nunca via Servidores de rota"
-
-msgid "Indicates if this network will announce its routes via route servers or not"
-msgstr "Indica se esta rede anunciará suas rotas via servidores de rota ou não"
-
-msgid "Peering Policy"
-msgstr "Política de Peering"
-
-msgid "General Policy"
-msgstr "Política geral"
-
-msgid "Multiple Locations"
-msgstr "Localidades Múltiplas"
-
-msgid "Ratio Requirement"
-msgstr "Requisito de Proporção"
-
-msgid "Contract Requirement"
-msgstr "Requisito de contrato"
-
-msgid "RIR status"
-msgstr "RIR status"
-
-msgid "RIR status updated"
-msgstr "Status do RIR atualizado"
-
-msgid "Network"
-msgstr "Rede"
-
-msgid "Networks"
-msgstr "Redes"
-
-msgid "Media Type"
-msgstr "Tipo de mídia"
-
-msgid "Company Website"
-msgstr "Website da Empresa"
-
-msgid "Traffic Stats Website"
-msgstr "Website de Estatísticas de Tráfego"
-
-msgid "Policy Email"
-msgstr "Email da Política"
-
-msgid "Policy Phone"
-msgstr "Telefone da Política"
-
-msgid "IX-F Network Count"
-msgstr "Contagem de rede IX-F"
-
-msgid "IX-F Last Import"
-msgstr "Log de importação IXF"
-
-msgid "Service Level"
-msgstr "Níveis de serviço"
-
-msgid "Terms"
-msgstr "Termos"
-
-msgid "Internet Exchange"
-msgstr "Internet Exchange"
-
-msgid "Internet Exchanges"
-msgstr "Internet Exchanges"
-
-msgid "Internet Exchange facility"
-msgstr "Internet Exchange PoP"
-
-msgid "Internet Exchange facilities"
-msgstr "Internet Exchange PoPs"
-
-msgid "Description"
-msgstr "Descrição"
-
-msgid "Route Server ASN"
-msgstr "ASN do Servidor de rotas"
-
-msgid "ARP sponging MAC"
-msgstr "ARP sponging MAC"
-
-msgid "IX-F Member Export URL"
-msgstr "URL de Exportação de Membro IXF"
-
-msgid "IX-F Member Export URL Visibility"
-msgstr "Visibilidade da URL de Exportação de Membro IXF"
-
-msgid "Internet Exchange LAN"
-msgstr "Internet Exchange LAN"
-
-msgid "Internet Exchange LANs"
-msgstr "Internet Exchange LANs"
-
-msgid "Protocol"
-msgstr "Protocolo"
-
-msgid "Prefix"
-msgstr "Prefixo"
-
-msgid "Internet Exchange LAN prefix"
-msgstr "Internet Exchange prefixo da LAN"
-
-msgid "Internet Exchange LAN prefixes"
-msgstr "Internet Exchange prefixos das LANs"
-
-msgid "Local ASN"
-msgstr "ASN local"
-
-msgid "Network Facility"
-msgstr "PoP de rede"
-
-msgid "Network Facilities"
-msgstr "PoPs de rede"
-
-msgid "RS peer"
-msgstr "RS peer"
-
-msgid "Speed (mbit/sec)"
-msgstr "Velocidade (mbit/seg)"
-
-msgid "Operational"
-msgstr "Operacional"
-
-msgid "Public Peering Exchange Point"
-msgstr "Internet Exchange de Peering Público"
-
-msgid "Public Peering Exchange Points"
-msgstr "Internet Exchange sde Peering Público"
-
-msgid "Carrier"
-msgstr "Operadora"
-
-msgid "Carriers"
-msgstr "Operadoras"
-
-msgid "Carrier presence at facility"
-msgstr "Presença da Operadora na Instalação"
-
-msgid "Carrier presences at facility"
-msgstr "Presenças da Operadora na Instalação"
-
-msgid "Campus Name"
-msgstr "Nome do Campus"
-
-msgid "Campus"
-msgstr "Campus"
-
-msgid "Campuses"
-msgstr "Campuses"
-
+#: mainsite/settings/__init__.py:1154
 msgid "Czech"
 msgstr "Tcheco"
 
+#: mainsite/settings/__init__.py:1155
 msgid "German"
 msgstr "Alemão"
 
+#: mainsite/settings/__init__.py:1156
 msgid "Greek"
 msgstr "Grego"
 
+#: mainsite/settings/__init__.py:1157
 msgid "English"
 msgstr "Inglês"
 
+#: mainsite/settings/__init__.py:1158
 msgid "Spanish"
 msgstr "Espanhol"
 
+#: mainsite/settings/__init__.py:1159
 msgid "French"
 msgstr "Francês"
 
+#: mainsite/settings/__init__.py:1160
 msgid "Italian"
 msgstr "Italiano"
 
+#: mainsite/settings/__init__.py:1161
 msgid "Japanese"
 msgstr "Japonês"
 
+#: mainsite/settings/__init__.py:1163
 msgid "Occitan"
 msgstr "Occitano"
 
+#: mainsite/settings/__init__.py:1164
 msgid "Portuguese"
 msgstr "Português"
 
+#: mainsite/settings/__init__.py:1165
 msgid "Romanian"
 msgstr "Romeno"
 
+#: mainsite/settings/__init__.py:1166
 msgid "Russian"
 msgstr "Russo"
 
+#: mainsite/settings/__init__.py:1167
 msgid "Chinese (Simplified)"
 msgstr "Chinês (Simplificado)"
 
+#: mainsite/settings/__init__.py:1168
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
+#: peeringdb_server/admin.py:128 peeringdb_server/templates/site/footer.html:46
 msgid "Status"
 msgstr "Estado"
 
+#: peeringdb_server/admin.py:271
 msgid "Target org cannot be in selected organizations list"
 msgstr "Organização de destino não pode estar na lista de organizações seleccionadas"
 
+#: peeringdb_server/admin.py:279
 msgid "There exist some sponsor ship conflicts that will need to be manually resolved before this merge can happen. {} has been notified of this conflict. Conflicting organizations: {}"
 msgstr "Existem alguns conflitos de envio de patrocinadores que precisarão ser resolvidos manualmente antes que essa mesclagem aconteça. {} foi notificado sobre esse conflito. Organizações conflitantes: {}"
 
+#: peeringdb_server/admin.py:430
 msgid "ROLLBACK"
 msgstr "Reversão"
 
+#: peeringdb_server/admin.py:444
 msgid "Ixlans can no longer be directly deleted as they are now synced to the parent exchange"
 msgstr "Ixlans não podem mais ser excluídos diretamente, pois agora estão sincronizados com o Exchange pai"
 
+#: peeringdb_server/admin.py:453
 msgid "Protected object '{}': {}"
 msgstr "Objeto protegido '{}': {}"
 
+#: peeringdb_server/admin.py:460
 msgid "Delete selected objects"
 msgstr "Excluir objetos selecionados"
 
+#: peeringdb_server/admin.py:463
 msgid "Please confirm deletion of selected objects."
 msgstr "Por favor, confirme a exclusão dos objetos selecionados."
 
+#: peeringdb_server/admin.py:467
 msgid "SOFT DELETE"
 msgstr "EXCLUSÃO SUAVE"
 
+#: peeringdb_server/admin.py:480
 msgid "Result length"
 msgstr "Tamanho do resultado"
 
+#: peeringdb_server/admin.py:485 peeringdb_server/admin.py:486
+#: peeringdb_server/admin.py:487 peeringdb_server/admin.py:488
+#: peeringdb_server/admin.py:489 peeringdb_server/admin.py:490
 msgid "Show {} rows"
 msgstr "Mostrar {} linhas"
 
+#: peeringdb_server/admin.py:679
 msgid "Verification Queue is currently disabled"
 msgstr "A fila de verificação está desativada"
 
+#: peeringdb_server/admin.py:681
 msgid "Verification Queue is currently disabled for this object type"
 msgstr "A fila de Verificação está atualmente desativada para este tipo de objeto"
 
+#: peeringdb_server/admin.py:690
 msgid "APPROVE"
 msgstr "APROVAR"
 
+#: peeringdb_server/admin.py:690
 msgid "DENY"
 msgstr "NEGAR"
 
+#: peeringdb_server/admin.py:693
 msgid "APPROVED"
 msgstr "APROVADO"
 
+#: peeringdb_server/admin.py:810
 msgid "User is looking to be affiliated to these Organizations"
 msgstr "Usuário/Utilizador está querendo se afiliar a essas organizações"
 
+#: peeringdb_server/admin.py:820
 msgid "User has these TOTP devices"
 msgstr "O usuário tem estes dispositivos TOTP"
 
+#: peeringdb_server/admin.py:830
 msgid "User has these Webauthn Security Keys"
 msgstr "O usuário possui estas chaves de segurança Webauthn"
 
+#: peeringdb_server/admin.py:888
 msgid "IX-F Import History"
 msgstr "Histórico de Importação IX-F"
 
+#: peeringdb_server/admin.py:901
+#: peeringdb_server/templates/site/view_organization_tools.html:384
+#: peeringdb_server/templates/site/view_organization_tools.html:562
+#: peeringdb_server/templates/site/view_suggest_ix.html:95
+#: peeringdb_server/templates/site/view_suggest_net.html:109
+#: peeringdb_server/views.py:2606
+msgid "Unicast IPv4"
+msgstr "Unicast IPv4"
+
+#: peeringdb_server/admin.py:902
+msgid "Unicast IPv6"
+msgstr "Unicast IPv6"
+
+#: peeringdb_server/admin.py:903
+#: peeringdb_server/templates/site/view_organization_tools.html:392
+#: peeringdb_server/templates/site/view_organization_tools.html:570
+#: peeringdb_server/templates/site/view_suggest_ix.html:103
+#: peeringdb_server/templates/site/view_suggest_net.html:117
+#: peeringdb_server/views.py:2611
+msgid "Multicast"
+msgstr "Multicast"
+
+#: peeringdb_server/admin.py:997
 msgid "Initial creation of netixlan"
 msgstr "Criação inicial de netixlan"
 
+#: peeringdb_server/admin.py:1018
 msgid "CAN BE ROLLED BACK"
 msgstr "PODE SER REVERTIDO"
 
+#: peeringdb_server/admin.py:1022 peeringdb_server/admin.py:1027
 msgid "CANNOT BE ROLLED BACK"
 msgstr "NÃO PODE SER REVERTIDO"
 
+#: peeringdb_server/admin.py:1022
 msgid "Has been changed since"
 msgstr "Foi alterado desde"
 
+#: peeringdb_server/admin.py:1028
 msgid "Netixlan with conflicting ipaddress now exists elsewhere"
 msgstr "Netixlan com endereço ip conflituante agora existe em outro lugar"
 
+#: peeringdb_server/admin.py:1032
 msgid "HAS BEEN ROLLED BACK"
 msgstr "FOI REVERTIDO"
 
+#: peeringdb_server/admin.py:1102
 msgid "Not Set"
 msgstr "Não configurado"
 
+#: peeringdb_server/admin.py:1107 peeringdb_server/admin.py:1147
+#: peeringdb_server/models.py:86
 msgid "Active"
 msgstr "Ativo"
 
+#: peeringdb_server/admin.py:1108 peeringdb_server/admin.py:1146
 msgid "Logo Missing"
 msgstr "Falta logotipo"
 
+#: peeringdb_server/admin.py:1110
 msgid "Over"
 msgstr "Sobre"
 
+#: peeringdb_server/admin.py:1112 peeringdb_server/models.py:6205
 msgid "Waiting"
 msgstr "Aguardando"
 
+#: peeringdb_server/admin.py:1117
 msgid "No organization(s) set"
 msgstr "Nenhuma organização definida"
 
+#: peeringdb_server/admin.py:1214
 msgid "Malformed organization ids"
 msgstr "Ids de organização malformados"
 
+#: peeringdb_server/admin.py:1220
 msgid "Merge target organization does not exist"
 msgstr "Mesclagem de organização de destino não existe"
 
+#: peeringdb_server/admin.py:1236
 msgid "Organization Merging Tool"
 msgstr "Ferramenta de Fusão de organizações"
 
+#: peeringdb_server/admin.py:1268 peeringdb_server/admin.py:1280
 msgid "Undo merge"
 msgstr "Desfazer merge"
 
+#: peeringdb_server/admin.py:1462
 msgid "ASN is already in use by another network"
 msgstr "ASN já está em uso por outra rede"
 
+#: peeringdb_server/admin.py:1470
 msgid "Name is already in use by another network"
 msgstr "O nome já está sendo usado por outra rede"
 
+#: peeringdb_server/admin.py:1666
 msgid "APPROVE selected items"
 msgstr "APROVAR itens selecionados"
 
+#: peeringdb_server/admin.py:1674
 msgid "DENY and delete selected items"
 msgstr "NEGAR e excluir os itens selecionados"
 
+#: peeringdb_server/admin.py:1680
 msgid "View"
 msgstr "Visualização"
 
+#: peeringdb_server/admin.py:1712 peeringdb_server/admin.py:1730
 msgid "Cannot approve a canceled affiliation request"
 msgstr "Não é possível aprovar uma solicitação de afiliação cancelada"
 
+#: peeringdb_server/admin.py:1720
 msgid "Affiliation request was approved and the user was notified."
 msgstr "Solicitação de afiliação foi aprovada e o usuário/utilizador foi notificado."
 
+#: peeringdb_server/admin.py:1723
 msgid "Approve and notify User"
 msgstr "Aprovar e notificar o Usuário"
 
+#: peeringdb_server/admin.py:1735
+#: peeringdb_server/templates/site/view_organization_tools.html:820
 msgid "Approve"
 msgstr "Aprovar"
 
+#: peeringdb_server/admin.py:1741
 msgid "Cannot deny a canceled affiliation request"
 msgstr "Não é possível negar uma solicitação de afiliação cancelada"
 
+#: peeringdb_server/admin.py:1745
+#: peeringdb_server/templates/site/view_organization_tools.html:821
 msgid "Deny"
 msgstr "Negar"
 
+#: peeringdb_server/admin.py:1762
 msgid "Usernames cannot start with \"apikey\""
 msgstr "Nomes de usuário não podem começar com “apikey”"
 
+#: peeringdb_server/admin.py:1867
+#: peeringdb_server/templates/site/profile-change-password.html:31
 msgid "Change Password"
 msgstr "Alterar senha"
 
+#: peeringdb_server/admin.py:1878
 msgid "Edit Permissions"
 msgstr "Editar permissões"
 
+#: peeringdb_server/admin.py:1883
 msgid "VERIFIED"
 msgstr "VERIFICADO"
 
+#: peeringdb_server/admin.py:1887
 msgid "UNVERIFIED"
 msgstr "NÃO VERIFICADO"
 
+#: peeringdb_server/admin.py:1901
 msgid "User Permission"
 msgstr "Permissão do usuário"
 
+#: peeringdb_server/admin.py:1902
 msgid "User Permissions"
 msgstr "Permissões do usuário"
 
+#: peeringdb_server/admin.py:2107 peeringdb_server/admin.py:2145
 msgid "Only POST requests allowed."
 msgstr "Somente solicitações POST permitidas."
 
+#: peeringdb_server/admin.py:2119
 msgid "{} (Preview)"
 msgstr "{} (Pré-visualização)"
 
+#: peeringdb_server/admin.py:2296
 msgid "Apply"
 msgstr "Aplicar"
 
+#: peeringdb_server/admin.py:2405
 msgid "No requirements"
 msgstr "Sem requisitos"
 
+#: peeringdb_server/admin.py:2443
 msgid "Value"
 msgstr "Valor"
 
+#: peeringdb_server/admin_commandline_tools.py:184
 msgid "This command is already waiting / running - please wait for it to finish before executing it again"
 msgstr "Este comando está já em espera / rodando - por favor espere o seu final antes de executa-lo novamente"
 
+#: peeringdb_server/admin_commandline_tools.py:200
 msgid "This command takes a while to complete and will be queued and ran in the background. No output log can be provided at this point in time. You may review once the command has finished."
 msgstr "Este comando demora um pouco para completar e será colocado em fila e executado em fundo. Nenhum registo de resultado pode ser fornecido neste momento. Poderá rever assim que o comando terminar a sua execução."
 
+#: peeringdb_server/admin_commandline_tools.py:234
 msgid "Old prefix - renumber all netixlans that fall into this prefix"
 msgstr "Prefixo antigo - renumere todos os netixlans que caiam neste prefixo"
 
+#: peeringdb_server/admin_commandline_tools.py:239
 msgid "New prefix - needs to be the same protocol and length as old prefix"
 msgstr "Novo prefixo - necessita ser do mesmo protocolo e comprimento tal como o prefixo antigo"
 
+#: peeringdb_server/admin_commandline_tools.py:279
 msgid "Merge this facility - it will be deleted"
 msgstr "Fundir está instalação - ela será excluída"
 
+#: peeringdb_server/admin_commandline_tools.py:285
 msgid "Target facility"
 msgstr "Instalação Alvo"
 
+#: peeringdb_server/admin_commandline_tools.py:320
 msgid "Undo this merge"
 msgstr "Desfazer esta fusão"
 
+#: peeringdb_server/admin_commandline_tools.py:351
 msgid "Don't delete users. Note that superuser accounts are always kept - regardless of this setting."
 msgstr "Não apague usuários. Note que as contas de superutilizador são sempre guardadas - independentemente da configuração."
 
+#: peeringdb_server/admin_commandline_tools.py:355
 msgid "Load data from peeringdb API"
 msgstr "Carregar dados da API do peeringdb"
 
+#: peeringdb_server/admin_commandline_tools.py:385
 msgid "Restore this object - search by [reftag] [id]"
 msgstr "Restaurar este objeto - procurar por [reftag] [id]"
 
+#: peeringdb_server/admin_commandline_tools.py:407
 msgid "Only {} type objects may be restored through this interface at this point"
 msgstr "Apenas objetos do tipo {} podem ser restaurados através deste interface neste momento"
 
+#: peeringdb_server/admin_commandline_tools.py:434
 msgid "Select an Internet Exchange to perform an ix-f memberdata import"
 msgstr "Selecione um Internet Exchange para realizar uma importação de dados de membro ix-f"
 
+#: peeringdb_server/admin_commandline_tools.py:443
 msgid "Reset all"
 msgstr "Redefinir tudo"
 
+#: peeringdb_server/admin_commandline_tools.py:446
 msgid "Reset hints"
 msgstr "Redefinir dicas"
 
+#: peeringdb_server/admin_commandline_tools.py:449
 msgid "Reset dismisses"
 msgstr "Redefinir descarta"
 
+#: peeringdb_server/admin_commandline_tools.py:452
 msgid "Reset email"
 msgstr "Redefinir email"
 
+#: peeringdb_server/admin_commandline_tools.py:455
 msgid "Reset tickets"
 msgstr "Redefinir tickets"
 
+#: peeringdb_server/admin_commandline_tools.py:493
 msgid "Select a handleref tag to validate"
 msgstr "Selecione uma tag handleref para validar"
 
+#: peeringdb_server/admin_commandline_tools.py:494
 msgid "Object type"
 msgstr "Tipo de objeto"
 
+#: peeringdb_server/admin_commandline_tools.py:498
 msgid "Enter a field name to validate"
 msgstr "Digite um nome de campo para validar"
 
+#: peeringdb_server/admin_commandline_tools.py:504
 msgid "Valid"
 msgstr "Válido"
 
+#: peeringdb_server/admin_commandline_tools.py:505
 msgid "Invalid"
 msgstr "Inválido"
 
+#: peeringdb_server/admin_commandline_tools.py:508
 msgid "Exclude data based on validation result"
 msgstr "Excluir dados com base no resultado da validação"
 
+#: peeringdb_server/admin_commandline_tools.py:512
 msgid "Verbose output"
 msgstr "Saída detalhada"
 
+#: peeringdb_server/api_key_views.py:151 peeringdb_server/api_key_views.py:186
+#: peeringdb_server/api_key_views.py:332
 msgid "Key not found"
 msgstr "Key not found"
 
+#: peeringdb_server/api_key_views.py:300
 msgid "This field is required."
 msgstr "Este campo é obrigatório."
 
+#: peeringdb_server/api_schema.py:218
 #, python-brace-format
 msgid "Retrieves a single `{obj_type}` type object by id"
 msgstr "Recupera um único objeto do tipo `{obj_type}` por id"
 
+#: peeringdb_server/api_schema.py:226 peeringdb_server/api_schema.py:251
 msgid "Expand nested sets according to depth."
 msgstr "Expanda os conjuntos aninhados de acordo com a profundidade."
 
+#: peeringdb_server/api_schema.py:242
 #, python-brace-format
 msgid "Retrieves a list of `{obj_type}` type objects"
 msgstr "Recupera uma lista de objetos do tipo `{obj_type}`"
 
+#: peeringdb_server/api_schema.py:264
 msgid "Limit the number of rows returned in the result set (use for pagination in combination with `skip`)"
 msgstr "Limite o número de linhas retornadas no conjunto de resultados (use para paginação em combinação com `skip`)"
 
+#: peeringdb_server/api_schema.py:275
 msgid "Skip n results in the result set (use for pagination in combination with `limit`)"
 msgstr "Pule n resultados no conjunto de resultados (use para paginação em combinação com `limit`)"
 
+#: peeringdb_server/api_schema.py:286
 msgid "Unix epoch time stamp (seconds). Only return objects that have been updated since then"
 msgstr "Carimbo de data/hora da época do Unix (segundos). Retornar apenas objetos que foram atualizados desde então"
 
+#: peeringdb_server/api_schema.py:348
 msgid "Filter results by matching a value against this field."
 msgstr "Filtre os resultados comparando um valor com este campo."
 
+#: peeringdb_server/api_schema.py:367
 msgid "Supported filter suffixes: {}"
 msgstr "Sufixos de filtro compatíveis: {}"
 
+#: peeringdb_server/api_schema.py:391
 msgid "Number of networks present at this facility"
 msgstr "Número de redes presentes nesta instalação"
 
+#: peeringdb_server/api_schema.py:402
 msgid "Targets both AKA and name fields for filtering"
 msgstr "Segmenta os campos AKA e de nome para filtragem"
 
+#: peeringdb_server/api_schema.py:409
 msgid "Find networks not present at an exchange (exchange id)"
 msgstr "Encontrar redes não presentes em um exchange (id do exchange)"
 
+#: peeringdb_server/api_schema.py:416
 msgid "Find networks present at exchange (exchange id)"
 msgstr "Encontrar redes presentes em um exchange(exchange id)"
 
+#: peeringdb_server/api_schema.py:423
 msgid "Find networks not present at a facility (facility id)"
 msgstr "Encontrar redes não presentes em uma instalação (facility id)"
 
+#: peeringdb_server/api_schema.py:430
 msgid "Find networks present at a facility (facility id)"
 msgstr "Encontrar redes presentes em uma instalação (facility id)"
 
+#: peeringdb_server/api_schema.py:437
 msgid "Find networks connected at ixlan (ixlan id)"
 msgstr "Encontre redes conectadas em ixlan (ixlan id)"
 
+#: peeringdb_server/api_schema.py:444
 msgid "Find the network that contains this netixlan (netixlan id)"
 msgstr "Encontre a rede que contém este netixlan (netixlan id)"
 
+#: peeringdb_server/api_schema.py:451
 msgid "Find the network that this netfac belongs to (netfac id)"
 msgstr "Encontre a rede a que este netfac pertence (netfac id)"
 
+#: peeringdb_server/api_schema.py:462
 msgid "Find exchanges present at a facility (facility id)"
 msgstr "Encontrar exchange presentes em uma instalação (facility id)"
 
+#: peeringdb_server/api_schema.py:469
 msgid "Find the exchange that contains this ixlan (ixlan id)"
 msgstr "Encontre o exchange que contém este ixlan (ixlan id)"
 
+#: peeringdb_server/api_schema.py:476
 msgid "Find the exchange that contains this ixfac (ixfac id)"
 msgstr "Encontre o exchange que contém este ixfac (ixfac id)"
 
+#: peeringdb_server/api_schema.py:482
 msgid "Number of networks present at this exchange"
 msgstr "Número de redes presentes neste exchange"
 
+#: peeringdb_server/api_schema.py:489
 msgid "Find exchanges where this network has a presence at (net id)"
 msgstr "Encontre exchange onde esta rede está presente (net id)"
 
+#: peeringdb_server/api_schema.py:500
 msgid "Find organization that contains the network (network asn)"
 msgstr "Encontre a organização que contém a rede (network asn)"
 
+#: peeringdb_server/api_schema.py:510
 msgid "Find prefixes by exchange (exchange id)"
 msgstr "Encontrar prefixos por exchange (exchange id)"
 
+#: peeringdb_server/api_schema.py:515
 msgid "Find prefixes by ip address"
 msgstr "Encontrar prefixos por endereço IP"
 
+#: peeringdb_server/api_schema.py:521
 msgid "Exchange name"
 msgstr "Nome do Exchange"
 
+#: peeringdb_server/api_schema.py:526
 msgid "Facility name"
 msgstr "Nome da Instalação"
 
+#: peeringdb_server/api_schema.py:527
 msgid "Facility country"
 msgstr "País da Instalação"
 
+#: peeringdb_server/api_schema.py:528
 msgid "Facility city"
 msgstr "Cidade da Instalação"
 
+#: peeringdb_server/api_schema.py:542
 #, python-brace-format
 msgid "Creates a new `{obj_type}` type object."
 msgstr "Cria um novo objeto de tipo `{obj_type}`."
 
+#: peeringdb_server/api_schema.py:609
 #, python-brace-format
 msgid "Updates an existing `{obj_type}` type object."
 msgstr "Atualiza um objeto de tipo `{obj_type}` existente."
 
+#: peeringdb_server/api_schema.py:623
 #, python-brace-format
 msgid "Marks an `{obj_type}` type object as `deleted`."
 msgstr "Marca um objeto do tipo `{obj_type}` como `deleted`."
 
+#: peeringdb_server/data_views.py:63 peeringdb_server/data_views.py:64
+#: peeringdb_server/data_views.py:68 peeringdb_server/data_views.py:73
+#: peeringdb_server/templates/site/view_organization_tools.html:806
+#: peeringdb_server/templates/site/view_organization_tools.html:814
+msgid "No"
+msgstr "Não"
+
+#: peeringdb_server/data_views.py:63 peeringdb_server/data_views.py:64
+#: peeringdb_server/data_views.py:69 peeringdb_server/data_views.py:74
+#: peeringdb_server/templates/site/view_organization_tools.html:806
+#: peeringdb_server/templates/site/view_organization_tools.html:814
 msgid "Yes"
 msgstr "Sim"
 
+#: peeringdb_server/data_views.py:67 peeringdb_server/data_views.py:72
+#: peeringdb_server/views.py:2553 peeringdb_server/views.py:2580
+#: peeringdb_server/views.py:2589 peeringdb_server/views.py:2596
+msgid "Not Disclosed"
+msgstr "Não divulgado"
+
+#: peeringdb_server/export_views.py:140
 msgid "Invalid export format"
 msgstr "Formato de exportação inválido"
 
+#: peeringdb_server/export_views.py:292
 msgid "Invalid tag"
 msgstr "Tag inválida"
 
+#: peeringdb_server/forms.py:46
 msgid "Invalid permission level"
 msgstr "Nível de permissão inválido"
 
+#: peeringdb_server/forms.py:83
 msgid "ASN needs to be a number"
 msgstr "ASN precisa ser um número"
 
+#: peeringdb_server/forms.py:94 peeringdb_server/views.py:1238
 msgid "Needs to be at least 10 characters long"
 msgstr "Precisa ter pelo menos 10 caracteres"
 
+#: peeringdb_server/forms.py:103
 msgid "Passwords need to match"
 msgstr "As senhas precisam coincidir"
 
+#: peeringdb_server/forms.py:115
 msgid "This username is already taken"
 msgstr "Este usuário já está sendo utilizado"
 
+#: peeringdb_server/forms.py:152
 msgid "Please fill out the anti-spam challenge (captcha) field"
 msgstr "Por favor preencha o campo do desafio (captcha) anti-spam"
 
+#: peeringdb_server/forms.py:165
 msgid "reCAPTCHA invalid"
 msgstr "reCAPTCHA inválido"
 
+#: peeringdb_server/forms.py:173
 msgid "captcha invalid"
 msgstr "captcha inválido"
 
+#: peeringdb_server/forms.py:233
 #, python-format
 msgid "File type %(value)s not allowed"
 msgstr "Tipo de arquivo %(value)s não permitido"
 
+#: peeringdb_server/forms.py:241
 #, python-format
 msgid "File size too big, max. %(value)s"
 msgstr "Tamanho do arquivo muito grande, máx. %(value)s"
 
+#: peeringdb_server/geo.py:92
 msgid "Error in forward geocode: No results found"
 msgstr "Erro no geocódigo de encaminhamento: nenhum resultado encontrado"
 
+#: peeringdb_server/import_views.py:63 peeringdb_server/import_views.py:139
 msgid "Please wait a bit before requesting another ixf import preview."
 msgstr "Aguarde um pouco antes de solicitar outra visualização de importação de ixf."
 
+#: peeringdb_server/import_views.py:70
 msgid "Ixlan not found"
 msgstr "Ixlan não encontrado"
 
+#: peeringdb_server/import_views.py:73 peeringdb_server/import_views.py:103
+#: peeringdb_server/import_views.py:149 peeringdb_server/views.py:3484
+#: peeringdb_server/views.py:3501
 msgid "Permission denied"
 msgstr "Permissão negada"
 
+#: peeringdb_server/import_views.py:91
 msgid "Please wait a bit before requesting another IX-F import postmortem."
 msgstr "Aguarde um pouco antes de solicitar outro post-mortem de importação IX-F."
 
+#: peeringdb_server/import_views.py:100 peeringdb_server/import_views.py:146
 msgid "Network not found"
 msgstr "Rede não encontrada"
 
+#: peeringdb_server/import_views.py:119
 msgid "Postmortem length cannot exceed {} entries"
 msgstr "O comprimento post mortem não pode exceder {} entradas"
 
+#: peeringdb_server/inet.py:164
 msgid "This ASN is not assigned by any RIR"
 msgstr "Este ASN não é atribuído por nenhum RIR"
 
+#: peeringdb_server/inet.py:166
 msgid "ASNs in this range are private or reserved"
 msgstr "ASNs neste intervalo são privados ou reservados"
 
+#: peeringdb_server/inet.py:168
 msgid "{}"
 msgstr "{}"
 
+#: peeringdb_server/ixf.py:47
 msgid "The entry for (asn and IPv4 and IPv6) does not exist in the exchange's IX-F data as a singular member connection"
 msgstr "A entrada para (asn e IPv4 e IPv6) não existe nos dados IX-F do exchange como uma conexão de membro singular"
 
+#: peeringdb_server/ixf.py:52
 msgid "The entry for (asn and IPv4 and IPv6) does not exist in PeeringDB as a singular network -> ix connection"
 msgstr "A entrada para (asn e IPv4 e IPv6) não existe no PeeringDB como uma rede singular -> conexão ix"
 
+#: peeringdb_server/ixf.py:57
 msgid "Data differences between PeeringDB and the exchange's IX-F data"
 msgstr "Diferenças de dados entre o PeeringDB e os dados IX-F da exchange"
 
+#: peeringdb_server/ixf.py:77
 msgid "We found that your IX-F output "
 msgstr "Descobrimos que sua saída IX-F "
 
+#: peeringdb_server/ixf.py:197 peeringdb_server/ixf.py:243
 msgid "IX-F import url not specified"
 msgstr "URL de importação IX-F não especificado"
 
+#: peeringdb_server/ixf.py:210
 msgid "No JSON could be parsed"
 msgstr "Nenhum JSON pôde ser analisado"
 
+#: peeringdb_server/ixf.py:249
 msgid "IX-F data not locally cached for this resource yet."
 msgstr "Dados IX-F ainda não armazenados localmente em cache para este recurso."
 
+#: peeringdb_server/ixf.py:480 peeringdb_server/ixf.py:488
 msgid "Address {} assigned to more than one distinct connection"
 msgstr "Endereço {} atribuído a mais de uma conexão distinta"
 
+#: peeringdb_server/ixf.py:534
 msgid "No prefixes defined on ixlan"
 msgstr "No prefixes defined on ixlan"
 
+#: peeringdb_server/ixf.py:857
 msgid "Network status is '{}'"
 msgstr "Estado da rede é '{}'"
 
+#: peeringdb_server/ixf.py:865
 msgid "Network does not exist in peeringdb"
 msgstr "Rede não existe no peeringdb"
 
+#: peeringdb_server/ixf.py:889
 msgid "Invalid connection state: {}"
 msgstr "Estado de conexão inválido: {}"
 
+#: peeringdb_server/ixf.py:913
 msgid "Could not find ipv4 or 6 address in vlan_list entry for vlan_id {} (AS{})"
 msgstr "Não foi possível encontrar o endereço ipv4 ou 6 na entrada vlan_list para vlan_id {} (AS{})"
 
+#: peeringdb_server/ixf.py:952
 msgid "Ip address error '{}' in vlan_list entry for vlan_id {}"
 msgstr "Erro de endereço IP ‘{}’ na entrada vlan_list para vlan_id {}"
 
+#: peeringdb_server/ixf.py:1103
 msgid "Invalid speed value: {}"
 msgstr "Valor de velocidade inválido: {}"
 
+#: peeringdb_server/ixf.py:1105
 msgid "Invalid speed value: could not be parsed"
 msgstr "Valor de velocidade inválido: não foi possível analisar"
 
+#: peeringdb_server/ixf.py:1247
 msgid "IP addresses moved to same entry"
 msgstr "Endereços IP movidos para a mesma entrada"
 
+#: peeringdb_server/ixf.py:1249 peeringdb_server/models.py:3757
+#: peeringdb_server/models.py:5142
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:208
 msgid "IPv6 not set"
 msgstr "IPv6 não definido"
 
+#: peeringdb_server/ixf.py:1251 peeringdb_server/models.py:3756
+#: peeringdb_server/models.py:5141
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:205
 msgid "IPv4 not set"
 msgstr "IPv4 não definido"
 
+#: peeringdb_server/ixf.py:1796
 msgid "PeeringDB: Action May Be Needed: IX-F Importer data mismatch between AS{} and one or more IXPs"
 msgstr "PeeringDB: ação pode ser necessária: incompatibilidade de dados do importador IX-F entre AS{} e um ou mais IXPs"
 
+#: peeringdb_server/ixf.py:1802
 msgid "PeeringDB: Action May Be Needed: IX-F Importer data mismatch between {} and one or more networks"
 msgstr "PeeringDB: ação pode ser necessária: incompatibilidade de dados do importador IX-F entre {} e uma ou mais redes"
 
+#: peeringdb_server/mail.py:98
 msgid "{} Merge Notification: {} -> {}"
 msgstr "{} Notificação de mesclagem: {} -> {}"
 
+#: peeringdb_server/models.py:87
 msgid "Inactive"
 msgstr "Inativo"
 
+#: peeringdb_server/models.py:91
+#: peeringdb_server/templates/site/sponsorships.html:63
 msgid "Silver"
 msgstr "Prata"
 
+#: peeringdb_server/models.py:92
+#: peeringdb_server/templates/site/sponsorships.html:46
 msgid "Gold"
 msgstr "Ouro"
 
+#: peeringdb_server/models.py:93
+#: peeringdb_server/templates/site/sponsorships.html:29
 msgid "Platinum"
 msgstr "Platina"
 
+#: peeringdb_server/models.py:94
+#: peeringdb_server/templates/site/sponsorships.html:12
 msgid "Diamond"
 msgstr "Diamante"
 
+#: peeringdb_server/models.py:104
 msgid "Data Validation"
 msgstr "Validação de dados"
 
+#: peeringdb_server/models.py:104
 msgid "RIR"
 msgstr "RIR"
 
+#: peeringdb_server/models.py:107
 msgid "Renumber IP Space"
 msgstr "Renumerar Espaço IP"
 
+#: peeringdb_server/models.py:108
 msgid "Merge Facilities"
 msgstr "Fundir PoPs"
 
+#: peeringdb_server/models.py:109
 msgid "Merge Facilities: UNDO"
 msgstr "Fundir PoPs: Desfazer"
 
+#: peeringdb_server/models.py:110
 msgid "Restore Object(s)"
 msgstr "Restaurar Objeto(s)"
 
+#: peeringdb_server/models.py:111
 msgid "Validate Data"
 msgstr "Validar dados"
 
+#: peeringdb_server/models.py:115
 msgid "1 Week"
 msgstr "1 Semana"
 
+#: peeringdb_server/models.py:116
 msgid "2 Weeks"
 msgstr "2 Semanas"
 
+#: peeringdb_server/models.py:117
 msgid "1 Month"
 msgstr "1 Mês"
 
+#: peeringdb_server/models.py:118
 msgid "6 Months"
 msgstr "6 Meses"
 
+#: peeringdb_server/models.py:119
 msgid "1 Year"
 msgstr "1 Ano"
 
+#: peeringdb_server/models.py:124
 msgid "Reset Environment"
 msgstr "Redefinir Ambiente"
 
+#: peeringdb_server/models.py:126 peeringdb_server/views.py:2331
 msgid "IX-F Import"
 msgstr "Importar IX-F"
 
+#: peeringdb_server/models.py:232
 #, python-format
 msgid "Object of type '%(type)s' cannot be saved because its parent entity '%(parent_tag)s/%(parent_id)s' has not yet been approved"
 msgstr "Objeto do tipo ‘%(type)s’ não pode ser salvo porque sua entidade pai ‘%(parent_tag)s/%(parent_id)s’ ainda não foi aprovada"
 
+#: peeringdb_server/models.py:239
 #, python-format
 msgid "Object of type '%(type)s' cannot be saved because its parent entity '%(parent_tag)s/%(parent_id)s' has been marked as deleted"
 msgstr "O objeto do tipo ‘%(type)s’ não pode ser salvo porque sua entidade pai ‘%(parent_tag)s/%(parent_id)s’ foi marcada como excluída"
 
+#: peeringdb_server/models.py:378
 msgid "Has this object's address been normalized with a call to the Google Maps API"
 msgstr "O endereço deste objeto foi normalizado com uma chamada para a API do Google Maps"
 
+#: peeringdb_server/models.py:382
 msgid "Last time of attempted geocode"
 msgstr "Última vez da tentativa de geocódigo"
 
+#: peeringdb_server/models.py:426
 msgid "Geo coding timed out"
 msgstr "A codificação geográfica expirou"
 
+#: peeringdb_server/models.py:428
 msgid "Geo coding failed: {}"
 msgstr "Falha na codificação geográfica: {}"
 
+#: peeringdb_server/models.py:440
 msgid "Geo location lookup timed out"
 msgstr "A pesquisa de localização geográfica expirou"
 
+#: peeringdb_server/models.py:442
 msgid "Geo location lookup failed: {}"
 msgstr "Falha na pesquisa de localização geográfica: {}"
 
+#: peeringdb_server/models.py:476
+msgid "Latitude"
+msgstr "Latitude"
+
+#: peeringdb_server/models.py:479
+msgid "Longitude"
+msgstr "Longitude"
+
+#: peeringdb_server/models.py:486
 msgid "Geocoordinate Cache"
 msgstr "Cache de geocoordenadas"
 
+#: peeringdb_server/models.py:487
 msgid "Geocoordinate Cache Entries"
 msgstr "Entradas de cache de geocoordenadas"
 
+#: peeringdb_server/models.py:602
 msgid "This organization in our database that was derived from the provided ASN or organization name. If this is empty it means no matching organization was found."
 msgstr "Esta organização em nosso banco de dados foi derivada do ASN fornecido ou nome da organização. Se estiver vazio, significa que nenhuma organização correspondente foi encontrada."
 
+#: peeringdb_server/models.py:611
 msgid "The organization name entered by the user"
 msgstr "O nome da organização inserido pelo usuário"
 
+#: peeringdb_server/models.py:614
 msgid "The ASN entered by the user"
 msgstr "A ASN inserido pelo usuário"
 
+#: peeringdb_server/models.py:619
 msgid "The user that made the request"
 msgstr "O usuário que fez a solicitação"
 
+#: peeringdb_server/models.py:628
+#: peeringdb_server/templates/site/view_campus_side.html:57
+#: peeringdb_server/templates/site/view_carrier_side.html:57
 msgid "Pending"
 msgstr "Pendente"
 
+#: peeringdb_server/models.py:629
 msgid "Approved"
 msgstr "Aprovado"
 
+#: peeringdb_server/models.py:630
 msgid "Denied"
 msgstr "Negado"
 
+#: peeringdb_server/models.py:631
 msgid "Canceled"
 msgstr "Cancelar"
 
+#: peeringdb_server/models.py:633
 msgid "Status of this request"
 msgstr "Status desta solicitação"
 
+#: peeringdb_server/models.py:638
 msgid "User to Organization Affiliation Request"
 msgstr "Solicitação de afiliação de usuário para organização"
 
+#: peeringdb_server/models.py:639
 msgid "User to Organization Affiliation Requests"
 msgstr "Solicitações de afiliação de usuário para organização"
 
+#: peeringdb_server/models.py:715
 msgid "Your affiliation to Organization \"{}\" has been approved"
 msgstr "Sua afiliação à Organização “{}” foi aprovada"
 
+#: peeringdb_server/models.py:749
 msgid "The item that this queue is attached to was created by this user"
 msgstr "O item ao qual esta fila está anexada foi criado por este usuário"
 
+#: peeringdb_server/models.py:758
 msgid "The item that this queue is attached to was created by this organization api key"
 msgstr "O item ao qual esta fila está anexada foi criado por esta chave de API da organização"
 
+#: peeringdb_server/models.py:845 peeringdb_server/models.py:1391
+#: peeringdb_server/models.py:5642
 msgid "email address"
 msgstr "endereço de email"
 
+#: peeringdb_server/models.py:853 peeringdb_server/models.py:3348
 msgid "Ticket reference on the DeskPRO side"
 msgstr "Referência do ticket no lado DeskPRO"
 
+#: peeringdb_server/models.py:857 peeringdb_server/models.py:3352
 msgid "Ticket id on the DeskPRO side"
 msgstr "Identificação do ticket no lado DeskPRO"
 
+#: peeringdb_server/models.py:861
 msgid "DeskPRO Ticket"
 msgstr "Ticket DeskPRO"
 
+#: peeringdb_server/models.py:862
 msgid "DeskPRO Tickets"
 msgstr "Tickets DeskPRO"
 
+#: peeringdb_server/models.py:880
 msgid "DeskPRO Ticket CC Contact"
 msgstr "Contato CC do Ticket DeskPRO"
 
+#: peeringdb_server/models.py:881
 msgid "Deskpro Ticket CC Contacts"
 msgstr "Contatos CC do Ticket DeskPRO"
 
+#: peeringdb_server/models.py:899
 msgid "Allows you to upload and set a logo image file for this organization"
 msgstr "Permite que você carregue e defina um arquivo de imagem de logotipo para esta organização"
 
+#: peeringdb_server/models.py:908
 msgid "Require users in your organization to have email addresses within your specified domains."
 msgstr "Exija que os usuários em sua organização tenham endereços de e-mail em seus domínios especificados."
 
+#: peeringdb_server/models.py:918
 msgid "If user email restriction is enabled: only allow users with emails in these domains. One domain per line, in the format of '@xyz.com'"
 msgstr "Se a restrição de e-mail do usuário estiver ativada: permita apenas usuários com e-mails nesses domínios. Um domínio por linha, no formato ‘@xyz.com’"
 
+#: peeringdb_server/models.py:928
 msgid "Require users in this organization to periodically re-authenticate"
 msgstr "Exigir que os usuários nesta organização se re-autentiquem periodicamente"
 
+#: peeringdb_server/models.py:1026
 msgid "Organization has active objects under it."
 msgstr "A organização tem objetos ativos sob ela."
 
+#: peeringdb_server/models.py:1030
 msgid "Organization is currently an active sponsor. Please contact PeeringDB support to help facilitate the removal of this organization."
 msgstr "A organização é atualmente um patrocinador ativo. Entre em contato com o suporte do PeeringDB para facilitar a remoção desta organização."
 
+#: peeringdb_server/models.py:1408 peeringdb_server/models.py:1409
 msgid "Organization API key Permission"
 msgstr "Permissão da chave de API da organização"
 
+#: peeringdb_server/models.py:1430
 msgid "Sponsorship starts on"
 msgstr "Patrocínio começa em"
 
+#: peeringdb_server/models.py:1432
 msgid "Sponsorship ends on"
 msgstr "Patrocínio termina em"
 
+#: peeringdb_server/models.py:1434
 msgid "Expiration notification sent on"
 msgstr "Notificação de expiração enviado em"
 
+#: peeringdb_server/models.py:1440
 msgid "Sponsorship"
 msgstr "Patrocínio"
 
+#: peeringdb_server/models.py:1441
 msgid "Sponsorships"
 msgstr "Patrocínios"
 
+#: peeringdb_server/models.py:1494
 msgid "Sponsorship Expired"
 msgstr "Patrocínio Expirado"
 
+#: peeringdb_server/models.py:1520 peeringdb_server/models.py:1550
+msgid "URL"
+msgstr "URL"
+
+#: peeringdb_server/models.py:1522
 msgid "If specified clicking the sponsorship will take the user to this location"
 msgstr "Se especificado, clicar no patrocínio levará o usuário a este local"
 
+#: peeringdb_server/models.py:1533
 msgid "Allows you to upload and set a logo image file for this sponsorship"
 msgstr "Permite que você carregue e defina um arquivo de imagem de logotipo para este patrocínio"
 
+#: peeringdb_server/models.py:1552
 msgid "If specified clicking the partnership will take the user to this location"
 msgstr "Se especificado, clicar na parceria levará o usuário a este local"
 
+#: peeringdb_server/models.py:1563
 msgid "Allows you to upload and set a logo image file for this partnership"
 msgstr "Permite que você carregue e defina um arquivo de imagem de logotipo para esta parceria"
 
+#: peeringdb_server/models.py:1569
 msgid "Partnership"
 msgstr "Parceria"
 
+#: peeringdb_server/models.py:1570
 msgid "Partnerships"
 msgstr "Parcerias"
 
+#: peeringdb_server/models.py:1589
 msgid "Merged on"
 msgstr "Fundido em"
 
+#: peeringdb_server/models.py:1593
 msgid "Organization Merge"
 msgstr "Fusão de organização"
 
+#: peeringdb_server/models.py:1594
 msgid "Organization Merges"
 msgstr "Fusões de organização"
 
+#: peeringdb_server/models.py:1654
 msgid "Organization Merge: Entity"
 msgstr "Fusão de organização: Entidade"
 
+#: peeringdb_server/models.py:1655
 msgid "Organization Merge: Entities"
 msgstr "Fusão de organização: Entidades"
 
+#: peeringdb_server/models.py:1671
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-affil.txt:6
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:23
+#: peeringdb_server/templates/oauth2_provider/application_list.html:15
+#: peeringdb_server/templates/site/advanced-search-campus.html:115
+#: peeringdb_server/templates/site/advanced-search-fac.html:26
+#: peeringdb_server/templates/site/advanced-search-ix.html:57
+#: peeringdb_server/templates/site/advanced-search-net.html:59
+#: peeringdb_server/templates/site/profile-affiliate.html:83
+#: peeringdb_server/views.py:663 peeringdb_server/views.py:1692
+#: peeringdb_server/views.py:1912 peeringdb_server/views.py:2011
+#: peeringdb_server/views.py:2138 peeringdb_server/views.py:2497
+msgid "Organization"
+msgstr "Organização"
+
+#: peeringdb_server/models.py:1789
+#: peeringdb_server/templates/site/view_organization_tools.html:126
+#: peeringdb_server/templates/site/view_organization_tools.html:322
+#: peeringdb_server/templates/site/view_organization_tools.html:514
+#: peeringdb_server/templates/site/view_organization_tools.html:710
+#: peeringdb_server/templates/site/view_organization_tools.html:752
+#: peeringdb_server/templates/site/view_suggest_fac.html:47
+#: peeringdb_server/templates/site/view_suggest_ix.html:47
+#: peeringdb_server/templates/site/view_suggest_net.html:47
+#: peeringdb_server/views.py:1505
+msgid "Website"
+msgstr "Website"
+
+#: peeringdb_server/models.py:1792 peeringdb_server/models.py:1793
 msgid "number of exchanges at this facility"
 msgstr "número de exchange neste PoP"
 
+#: peeringdb_server/models.py:1798 peeringdb_server/models.py:1799
 msgid "number of networks at this facility"
 msgstr "número de redes neste PoP"
 
+#: peeringdb_server/models.py:1956 peeringdb_server/models.py:2353
 msgid "Need to specify at least two asns"
 msgstr "Precisa especificar pelo menos dois asns"
 
+#: peeringdb_server/models.py:1959 peeringdb_server/models.py:2356
 msgid "Can only compare a maximum of 25 asns"
 msgstr "Só pode comparar um máximo de 25 ASNs"
 
+#: peeringdb_server/models.py:2041
 msgid "Facility has active exchange presence(s): {} ..."
 msgstr "PoP tem conexão(ões) com exchange(s) ativo(s): {} …"
 
+#: peeringdb_server/models.py:2049
 msgid "Facility has active network presence(s): {} ..."
 msgstr "PoP tem conexão(ões) com rede(s) ativo(s): {} …"
 
+#: peeringdb_server/models.py:2078
 msgid "Manual IX-F import request"
 msgstr "Solicitação de importação manual do IX-F"
 
+#: peeringdb_server/models.py:2079
 msgid "Date of most recent manual import request"
 msgstr "Data da solicitação de importação manual mais recente"
 
+#: peeringdb_server/models.py:2085
 msgid "Manual IX-F import status"
 msgstr "Status de importação IX-F manual"
 
+#: peeringdb_server/models.py:2086
 msgid "The current status of the manual ix-f import request"
 msgstr "O status atual da solicitação de importação manual do ix-f"
 
+#: peeringdb_server/models.py:2088
 msgid "Queued"
 msgstr "Enfileirados"
 
+#: peeringdb_server/models.py:2089
 msgid "Importing"
 msgstr "Importando"
 
+#: peeringdb_server/models.py:2090
 msgid "Finished"
 msgstr "Finalizado"
 
+#: peeringdb_server/models.py:2091
 msgid "Import failed"
 msgstr "Falha na importação"
 
+#: peeringdb_server/models.py:2101
 msgid "The user that triggered the manual ix-f import request"
 msgstr "O usuário que acionou a solicitação de importação manual do ix-f"
 
+#: peeringdb_server/models.py:2111 peeringdb_server/models.py:2112
 msgid "number of facilities at this exchange"
 msgstr "número de exchange nesta instalação"
 
+#: peeringdb_server/models.py:2118 peeringdb_server/models.py:2119
 msgid "number of networks at this exchange"
 msgstr "número de redes presentes neste exchange"
 
+#: peeringdb_server/models.py:2563
 msgid "Exchange has active facility connection(s): {} ..."
 msgstr "Exchange tem conexão(ões) de instalação ativa(s): {} …"
 
+#: peeringdb_server/models.py:2567
 msgid "Exchange has active peer(s)"
 msgstr "O Exchange tem pares ativos"
 
+#: peeringdb_server/models.py:2792
 msgid "IX-F error"
 msgstr "Erro IX-F"
 
+#: peeringdb_server/models.py:2795
 msgid "Reason IX-F data could not be parsed"
 msgstr "Os dados do motivo IX-F não puderam ser analisados"
 
+#: peeringdb_server/models.py:2798
 msgid "IX-F error notification date"
 msgstr "Data de notificação do erro IX-F"
 
+#: peeringdb_server/models.py:2799
 msgid "Last time we notified the exchange about the IX-F parsing issue"
 msgstr "A última vez que notificamos a bolsa sobre o problema de análise IX-F"
 
+#: peeringdb_server/models.py:2804
 msgid "IX-F sent IPs for unsupported protocol"
 msgstr "IX-F enviou IPs para protocolo não suportado"
 
+#: peeringdb_server/models.py:2806
 msgid "IX has been sending IP addresses for protocol not supported by network"
 msgstr "IX tem enviado endereços IP para protocolo não suportado pela rede"
 
+#: peeringdb_server/models.py:2921
 msgid "IXLan id needs to match parent ix id"
 msgstr "IXLan id precisa corresponder ao pai ix id"
 
+#: peeringdb_server/models.py:2929
 msgid "Ixlan for exchange already exists"
 msgstr "Ixlan para o exchange já existe"
 
+#: peeringdb_server/models.py:2938 peeringdb_server/serializers.py:2930
 msgid "Cannot enable IX-F import without specifying the IX-F member list url"
 msgstr "Não é possível ativar a importação IX-F sem especificar o URL da lista de membros IX-F"
 
+#: peeringdb_server/models.py:3179
 msgid "IX-F Import Log"
 msgstr "Log de Importação IX-F"
 
+#: peeringdb_server/models.py:3180
 msgid "IX-F Import Logs"
 msgstr "Logo de Importação IX-F"
 
+#: peeringdb_server/models.py:3238
 msgid "IX-F Import Log Entry"
 msgstr "Entrada de registro de importação IX-F"
 
+#: peeringdb_server/models.py:3239
 msgid "IX-F Import Log Entries"
 msgstr "Entradas de registro de importação IX-F"
 
+#: peeringdb_server/models.py:3302
 msgid "JSON snapshot of the ix-f member data that created this entry"
 msgstr "Instantâneo JSON dos dados do membro ix-f que criaram esta entrada"
 
+#: peeringdb_server/models.py:3305
 msgid "Activity for this entry"
 msgstr "Atividade para esta entrada"
 
+#: peeringdb_server/models.py:3310
 msgid "Network's dismissal of this proposed change, which will hide it until from the customer facing network view"
 msgstr "A rejeição da rede a essa alteração proposta, que a ocultará até que a visualização da rede voltada para o cliente"
 
+#: peeringdb_server/models.py:3316
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:145
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:350
+#: peeringdb_server/templates/site/view_network_side.html:35
+#: peeringdb_server/templates/site/view_network_side.html:198
 msgid "RS Peer"
 msgstr "Peer RS"
 
+#: peeringdb_server/models.py:3322
 msgid "Trying to apply data to peeringdb raised an issue"
 msgstr "Tentar aplicar dados ao peeringdb levantou um problema"
 
+#: peeringdb_server/models.py:3327
 msgid "Last Fetched"
 msgstr "Última coleta"
 
+#: peeringdb_server/models.py:3339
 msgid "Requirement of another IXFMemberData entry and will be applied alongside it"
 msgstr "Exigência de outra entrada IXFMemberData e será aplicada juntamente com ela"
 
+#: peeringdb_server/models.py:3358
 msgid "Indicates how many extra notifications were sent to the network for this proposal. Extra notifications can be sent for stale netixlan entries over time."
 msgstr "Indica quantas notificações extras foram enviadas à rede para esta proposta. Notificações extras podem ser enviadas para entradas netixlan obsoletas ao longo do tempo."
 
+#: peeringdb_server/models.py:3365
 msgid "Last time extra notifications were sent to the network for this proposal."
 msgstr "Última vez que notificações extras foram enviadas à rede para esta proposta."
 
+#: peeringdb_server/models.py:3380 peeringdb_server/models.py:3381
 msgid "IX-F Member Data"
 msgstr "Dados do Associado IX-F"
 
+#: peeringdb_server/models.py:3481
 msgid "No suitable ipaddresses when validating against the enabled network protocols"
 msgstr "Nenhum endereço iPad adequado ao validar contra os protocolos de rede ativados"
 
+#: peeringdb_server/models.py:4527
 msgid "IXLanPrefix with status '{}' cannot be linked to a IXLan with status '{}'."
 msgstr "IXLanPrefix com status ‘{}’ não pode ser vinculado a um IXLan com status ‘{}’."
 
+#: peeringdb_server/models.py:4571
 msgid "Specifies whether an IXP is allowed to add a netixlan entry for this network via their ixp_member data"
 msgstr "Especifica se um IXP tem permissão para adicionar uma entrada netixlan para esta rede por meio de seus dados ixp_member"
 
+#: peeringdb_server/models.py:4580 peeringdb_server/models.py:4581
 msgid "number of exchanges at this network"
 msgstr "número de exchange nesta rede"
 
+#: peeringdb_server/models.py:4587 peeringdb_server/models.py:4588
 msgid "number of facilities at this network"
 msgstr "número de PoPs nesta rede"
 
+#: peeringdb_server/models.py:4934
 msgid "Last technical contact point for network with active peers"
 msgstr "Último ponto de contato técnico para rede com pares ativos"
 
+#: peeringdb_server/models.py:4945 peeringdb_server/models.py:4946
+#: peeringdb_server/serializers.py:2044 peeringdb_server/serializers.py:2045
 msgid "Phone or email required"
 msgstr "Telefone ou e-mail obrigatório"
 
+#: peeringdb_server/models.py:5047 peeringdb_server/models.py:5434
+#: peeringdb_server/serializers.py:2259 peeringdb_server/serializers.py:2387
 msgid "This entity was created for the ASN {} - please remove it from this network and recreate it under the correct network"
 msgstr "Esta entidade foi criada para o ASN {} - remova-a desta rede e recrie-a na rede correta"
 
+#: peeringdb_server/models.py:5221
 msgid "IPv4 address outside of prefix"
 msgstr "Endereço IPv4 fora do prefixo"
 
+#: peeringdb_server/models.py:5225
 msgid "IPv6 address outside of prefix"
 msgstr "Endereço IPv6 fora do prefixo"
 
+#: peeringdb_server/models.py:5353
 msgid "Maximum speed: {}"
 msgstr "Velocidade máxima: {}"
 
+#: peeringdb_server/models.py:5359
 msgid "Minimum speed: {}"
 msgstr "Velocidade mínima: {}"
 
+#: peeringdb_server/models.py:5381 peeringdb_server/models.py:5383
+#: peeringdb_server/serializers.py:2236 peeringdb_server/serializers.py:2238
 msgid "IP already exists"
 msgstr "IP já existe"
 
+#: peeringdb_server/models.py:5628
 msgid "username"
 msgstr "nome de usuário"
 
+#: peeringdb_server/models.py:5631
 msgid "Required. Letters, digits and [@.+-/_=|] only."
 msgstr "Obrigatório. Letras, dígitos e [@.+-/_=|] apenas."
 
+#: peeringdb_server/models.py:5635
 msgid "Enter a valid username."
 msgstr "Insira um nome de usuário válido."
 
+#: peeringdb_server/models.py:5644
 msgid "first name"
 msgstr "primeiro nome"
 
+#: peeringdb_server/models.py:5645
 msgid "last name"
 msgstr "último nome"
 
+#: peeringdb_server/models.py:5647
 msgid "staff status"
 msgstr "status da equipe"
 
+#: peeringdb_server/models.py:5649
 msgid "Designates whether the user can log into admin site."
 msgstr "Designa se o usuário pode fazer login no site de administração."
 
+#: peeringdb_server/models.py:5652
 msgid "active"
 msgstr "ativo"
 
+#: peeringdb_server/models.py:5655
 msgid "Designates whether this user should be treated as active. Unselect this instead of deleting accounts."
 msgstr "Designa se este usuário deve ser tratado como ativo. Desmarque esta opção em vez de excluir contas."
 
+#: peeringdb_server/models.py:5658
 msgid "date joined"
 msgstr "data de adesão"
 
+#: peeringdb_server/models.py:5661
 msgid "status"
 msgstr "status"
 
+#: peeringdb_server/models.py:5665
 msgid "The user's primary organization"
 msgstr "A organização principal do usuário"
 
+#: peeringdb_server/models.py:5668
 msgid "language"
 msgstr "idioma"
 
+#: peeringdb_server/models.py:5680
 msgid "Account is orphaned and has been flagged for deletion at this date"
 msgstr "A conta está órfã e foi sinalizada para exclusão nesta data"
 
+#: peeringdb_server/models.py:5688
 msgid "User has been notified about pending account deletion at this date"
 msgstr "O usuário foi notificado sobre a exclusão pendente da conta nesta data"
 
+#: peeringdb_server/models.py:5695
 msgid "This user will never be flagged for deletion through the orphaned user cleanup process."
 msgstr "Este usuário nunca será sinalizado para exclusão por meio do processo de limpeza de usuário órfão."
 
+#: peeringdb_server/models.py:5706
 msgid "user"
 msgstr "usuário"
 
+#: peeringdb_server/models.py:5707
 msgid "users"
 msgstr "usuários"
 
+#: peeringdb_server/models.py:6023
 msgid "Password Reset Initiated"
 msgstr "Redefinição de senha Iniciada"
 
+#: peeringdb_server/models.py:6103
 msgid "Determines if API Key inherits the User Permissions or is readonly."
 msgstr "Determina se a chave de API herda as permissões do usuário ou é somente leitura."
 
+#: peeringdb_server/models.py:6147
 msgid "IX-F Import Email"
 msgstr "E-mail de Importação IX-F"
 
+#: peeringdb_server/models.py:6148
 msgid "IX-F Import Emails"
 msgstr "E-mails de Importação IX-F"
 
+#: peeringdb_server/models.py:6178
 msgid "name of the tool"
 msgstr "nome da ferramenta"
 
+#: peeringdb_server/models.py:6181
 msgid "json serialization of arguments and options passed"
 msgstr "serialização json de argumentos e opções passadas"
 
+#: peeringdb_server/models.py:6183
 msgid "result log"
 msgstr "log de resultados"
 
+#: peeringdb_server/models.py:6186
 msgid "Descriptive text of command that can be searched"
 msgstr "Texto descritivo do comando que pode ser pesquisado"
 
+#: peeringdb_server/models.py:6193
 msgid "the user that ran this command"
 msgstr "o usuário que executou este comando"
 
+#: peeringdb_server/models.py:6197
 msgid "command was run at this date and time"
 msgstr "comando foi executado nesta data e hora"
 
+#: peeringdb_server/models.py:6204
 msgid "Done"
 msgstr "Terminado"
 
+#: peeringdb_server/models.py:6206
 msgid "Running"
 msgstr "Executando"
 
+#: peeringdb_server/models.py:6232
 msgid "Environment Setting"
 msgstr "Configuração do ambiente"
 
+#: peeringdb_server/models.py:6233
 msgid "Environment Settings"
 msgstr "Configurações do ambiente"
 
+#: peeringdb_server/models.py:6244
 msgid "API: Anonymous API throttle rate"
 msgstr "API: taxa de supressão da API anônima"
 
+#: peeringdb_server/models.py:6248
 msgid "API: Authenticated API throttle rate"
 msgstr "API: taxa de supressão da API autenticada"
 
+#: peeringdb_server/models.py:6253
 msgid "API: Melissa request throttle rate for admin users"
 msgstr "API: Melissa solicita taxa de supressão para usuários administradores"
 
+#: peeringdb_server/models.py:6257
 msgid "API: Melissa request throttle enabled for admin users"
 msgstr "API: Melissa solicita supressão ativado para usuários administradores"
 
+#: peeringdb_server/models.py:6261
 msgid "API: Melissa request throttle rate for users"
 msgstr "API: Melissa solicita taxa de supressão para usuários"
 
+#: peeringdb_server/models.py:6265
 msgid "API: Melissa request throttle enabled for users"
 msgstr "API: Melissa solicita supressão ativado para usuários"
 
+#: peeringdb_server/models.py:6269
 msgid "API: Melissa request throttle rate for organizations"
 msgstr "API: Melissa solicita taxa de supressão para organizações"
 
+#: peeringdb_server/models.py:6273
 msgid "API: Melissa request throttle enabled for organizations"
 msgstr "API: Melissa solicita supressão ativado para organizações"
 
+#: peeringdb_server/models.py:6277
 msgid "API: Melissa request throttle rate for anonymous requests (ips)"
 msgstr "API: Melissa solicita taxa de supressão para solicitações anônimas (ips)"
 
+#: peeringdb_server/models.py:6281
 msgid "API: Melissa request throttle enabled for anonymous requests (ips)"
 msgstr "API: Melissa solicita supressão ativado para solicitações anônimas (ips)"
 
+#: peeringdb_server/models.py:6287
 msgid "API: Repeated request throttle size threshold for ip blocks (bytes)"
 msgstr "API: Limite de tamanho da supressão de solicitação repetida para blocos IP (bytes)"
 
+#: peeringdb_server/models.py:6292
 msgid "API: Repeated request throttle rate for ip blocks"
 msgstr "API: taxa de supressão de solicitação repetida para blocos de IP"
 
+#: peeringdb_server/models.py:6296
 msgid "API: Repeated request throttle enabled for ip blocks"
 msgstr "API: supressão de solicitação repetida ativado para blocos de IP"
 
+#: peeringdb_server/models.py:6302
 msgid "API: Repeated request throttle size threshold for ip addresses (bytes)"
 msgstr "API: Limite de tamanho da supressão de solicitação para endereços IP (bytes)"
 
+#: peeringdb_server/models.py:6307
 msgid "API: Repeated request throttle rate for ip addresses"
 msgstr "API: taxa de supressão de solicitação repetida para endereços IP"
 
+#: peeringdb_server/models.py:6311
 msgid "API: Repeated request throttle enabled for ip addresses"
 msgstr "API: supressão de solicitação repetida ativado para endereços IP"
 
+#: peeringdb_server/models.py:6317
 msgid "API: Repeated request throttle size threshold for authenticated users (bytes)"
 msgstr "API: Limite de tamanho da supressão de solicitação para usuários autenticados (bytes)"
 
+#: peeringdb_server/models.py:6322
 msgid "API: Repeated request throttle rate for authenticated users"
 msgstr "API: taxa de supressão de solicitação repetida para usuários autenticados"
 
+#: peeringdb_server/models.py:6326
 msgid "API: Repeated request throttle enabled for authenticated users"
 msgstr "API: supressão de solicitação repetida ativado para usuários autenticados"
 
+#: peeringdb_server/models.py:6332
 msgid "API: Repeated request throttle size threshold for organization api-keys (bytes)"
 msgstr "API: Limite de tamanho da supressão de solicitação para chaves de API da organização (bytes)"
 
+#: peeringdb_server/models.py:6337
 msgid "API: Repeated request throttle rate for organization api-keys"
 msgstr "API: taxa de supressão de solicitação repetida para chaves de API da organização"
 
+#: peeringdb_server/models.py:6341
 msgid "API: Repeated request throttle enabled for organization api-keys"
 msgstr "API: supressão de solicitação repetida ativado para chaves de API da organização"
 
+#: peeringdb_server/models.py:6346
 msgid "API: Anonymous API throttle rate message"
 msgstr "API: mensagem da taxa de supressão da API anônima"
 
+#: peeringdb_server/models.py:6350
 msgid "API: Authenticated API throttle rate message"
 msgstr "API: mensagem da taxa de supressão da API autenticada"
 
+#: peeringdb_server/models.py:6362 peeringdb_server/views.py:1544
+#: peeringdb_server/views.py:1775 peeringdb_server/views.py:1940
+#: peeringdb_server/views.py:2051 peeringdb_server/views.py:2192
+#: peeringdb_server/views.py:2632
 msgid "Last Updated"
 msgstr "Ultima atualização"
 
+#: peeringdb_server/models.py:6369
 msgid "Configured on"
 msgstr "Configurado em"
 
+#: peeringdb_server/models.py:6380
 msgid "Last updated by this user"
 msgstr "Última atualização por este usuário"
 
+#: peeringdb_server/models.py:6495
 msgid "application is owned by this organization"
 msgstr "o aplicativo é de propriedade desta organização"
 
+#: peeringdb_server/models.py:6504
 msgid "OAuth Application"
 msgstr "Aplicação OAuth"
 
+#: peeringdb_server/models.py:6505
 msgid "OAuth Applications"
 msgstr "Aplicações OAuth"
 
+#: peeringdb_server/models.py:6517
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-affil.txt:7
+#: peeringdb_server/templates/site/view_organization_side.html:113
+msgid "Network"
+msgstr "Rede"
+
+#: peeringdb_server/models.py:6525
 msgid "Added"
 msgstr "Adicionado"
 
+#: peeringdb_server/models.py:6526
 msgid "Updated"
 msgstr "Atualizado"
 
+#: peeringdb_server/models.py:6527
 msgid "Deleted"
 msgstr "Deletado"
 
+#: peeringdb_server/models.py:6550
 msgid "User started watching this object at this time"
 msgstr "O usuário começou a assistir a este objeto neste momento"
 
+#: peeringdb_server/models.py:6558
 msgid "Last time user was notified about changes to this object"
 msgstr "Última vez que o usuário foi notificado sobre alterações neste objeto"
 
+#: peeringdb_server/models.py:6563 peeringdb_server/models.py:6564
 msgid "Data Change Watched Object"
 msgstr "Alteração de dados no objeto monitorado"
 
+#: peeringdb_server/models.py:6707
 msgid "Reason for notification"
 msgstr "Motivo da notificação"
 
+#: peeringdb_server/models.py:6732
 msgid "Source of automated update"
 msgstr "Fonte de atualização automática"
 
+#: peeringdb_server/models.py:6738 peeringdb_server/models.py:6739
 msgid "Data Change Notification Queue"
 msgstr "Alteração de dados na fila de notificação"
 
+#: peeringdb_server/models.py:6941
 msgid "Data Change Email"
 msgstr "E-mail de alteração de dados"
 
+#: peeringdb_server/models.py:6942
 msgid "Data Change Emails"
 msgstr "E-mails de alteração de dados"
 
+#: peeringdb_server/org_admin_views.py:157
 msgid "Organization and all Entities it owns"
 msgstr "Organização e todas as Entidades que possui"
 
+#: peeringdb_server/org_admin_views.py:158
 msgid "Any Network"
 msgstr "Qualquer rede"
 
+#: peeringdb_server/org_admin_views.py:159
 msgid "Any Facility"
 msgstr "Qualquer PoP"
 
+#: peeringdb_server/org_admin_views.py:160
 msgid "Any Exchange"
 msgstr "Qualquer Exchange"
 
+#: peeringdb_server/org_admin_views.py:161
 msgid "Manage peering sessions - Any Network"
 msgstr "Gerenciar sessões de emparelhamento - Qualquer rede"
 
+#: peeringdb_server/org_admin_views.py:167
 #, python-format
 msgid "Manage peering sessions - %(net_name)s"
 msgstr "Gerenciar sessões de emparelhamento - %(net_name)s"
 
+#: peeringdb_server/org_admin_views.py:175
 #, python-format
 msgid "Network - %(net_name)s"
 msgstr "Rede - %(net_name)s"
 
+#: peeringdb_server/org_admin_views.py:182
 #, python-format
 msgid "Exchange - %(ix_name)s"
 msgstr "Exchange - %(ix_name)s"
 
+#: peeringdb_server/org_admin_views.py:189
 #, python-format
 msgid "Facility - %(fac_name)s"
 msgstr "PoP - %(fac_name)s"
 
+#: peeringdb_server/org_admin_views.py:259
 msgid "Invalid organization specified"
 msgstr "Organização inválida especificada"
 
+#: peeringdb_server/org_admin_views.py:369
 msgid "Needs to be member or admin"
 msgstr "Precisa ser membro ou administrador"
 
+#: peeringdb_server/org_admin_views.py:431
 msgid "Cannot manage permissions for organization admins"
 msgstr "Não é possível gerenciar permissões para administradores da organização"
 
+#: peeringdb_server/org_admin_views.py:523
 #, python-format
 msgid "%(user_name)s's affiliation request has been approved"
 msgstr "A solicitação de afiliação de %(user_name)s foi aprovada"
 
+#: peeringdb_server/org_admin_views.py:580
 #, python-format
 msgid "%(user_name)s's affiliation request has been denied"
 msgstr "A solicitação de afiliação de %(user_name)s foi negada"
 
+#: peeringdb_server/rest.py:83
 msgid "This key is currently inactive - please contact PeeringDB support for assistance."
 msgstr "Esta chave está inativa no momento - entre em contato com o suporte do PeeringDB para obter assistência."
 
+#: peeringdb_server/rest.py:849
 msgid "Please contact {} to help with the deletion of this object"
 msgstr "Entre em contato com {} para ajudar na exclusão deste objeto"
 
+#: peeringdb_server/serializers.py:138
 msgid "We could not find the address you entered. Please review your address data and contact {} for further assistance if needed."
 msgstr "Não foi possível encontrar o endereço que você digitou. Revise seus dados de endereço e entre em contato com {} para obter mais assistência, se necessário."
 
+#: peeringdb_server/serializers.py:386
 msgid "Invalid value"
 msgstr "Valor inválido"
 
+#: peeringdb_server/serializers.py:452 peeringdb_server/serializers.py:476
 msgid "This field is required"
 msgstr "Este campo é obrigatório"
 
+#: peeringdb_server/serializers.py:502
 msgid "RDAP Lookup Error"
 msgstr "Erro de pesquisa RDAP"
 
+#: peeringdb_server/serializers.py:539
 #, python-brace-format
 msgid "This field is only allowed for these requests: {methods}"
 msgstr "Este campo só é permitido para estas solicitações: {methods}"
 
+#: peeringdb_server/serializers.py:1431
 msgid "Required for distance filtering"
 msgstr "Necessário para filtragem de distância"
 
+#: peeringdb_server/serializers.py:2208
 msgid "Network must have a Technical, NOC, or Policy point of contact with valid email before adding exchange point."
 msgstr "A rede deve ter um ponto de contato técnico, NOC ou político com e-mail válido antes de adicionar o exchange."
 
+#: peeringdb_server/serializers.py:2605
 msgid "Network has been deleted. Please contact {}"
 msgstr "Network has been deleted. Please contact {}"
 
+#: peeringdb_server/serializers.py:2631 peeringdb_server/serializers.py:3231
 msgid "This field may not be blank."
 msgstr "Este campo não pode ficar em branco."
 
+#: peeringdb_server/serializers.py:2680
 msgid "ASN cannot be changed."
 msgstr "O ASN não pode ser alterado."
 
+#: peeringdb_server/serializers.py:2833
 msgid "The `in_dfz` property has been deprecated and setting it to `False` is no longer supported"
 msgstr "A propriedade `in_dfz` foi descontinuada e defini-la como `False` não é mais suportada"
 
+#: peeringdb_server/serializers.py:3002
 msgid "Specify at least one email address"
 msgstr "Especifique pelo menos um endereço de e-mail"
 
+#: peeringdb_server/serializers.py:3199
 msgid "User cannot create an internet exchange withits org set as the SUGGEST_ENTITY organization"
 msgstr "O usuário não pode criar um internet exchange com sua organização definida como a organização SUGGEST_ENTITY"
 
+#: peeringdb_server/signals.py:185
 msgid "Facility cannot be made part of a campus as it is missing its geolocation coordinates"
 msgstr "O Pop não pode fazer parte de um campus, pois não possui as coordenadas de geolocalização"
 
+#: peeringdb_server/signals.py:210
 #, python-brace-format
 msgid "Facility out of campus bounds (max. {settings.CAMPUS_MAX_DISTANCE}km)"
 msgstr "PoP fora dos limites do campus (max. {settings.CAMPUS_MAX_DISTANCE}km)"
 
+#: peeringdb_server/signals.py:405
 #, python-format
 msgid "User %(u_name)s wishes to be affiliated to your Organization"
 msgstr "O usuário %(u_name)s deseja ser afiliado à sua organização"
 
+#: peeringdb_server/templates/account/email_confirm.html:13
 msgid "Confirm your e-mail address"
 msgstr "Confirme seu endereço de e-mail"
 
+#: peeringdb_server/templates/account/email_confirm.html:15
 msgid "Please confirm that"
 msgstr "Por favor, confirme que"
 
+#: peeringdb_server/templates/account/email_confirm.html:15
 msgid "is your email-address"
 msgstr "é o seu endereço de e-mail"
 
+#: peeringdb_server/templates/account/email_confirm.html:19
 msgid "Confirm"
 msgstr "Confirmar"
 
+#: peeringdb_server/templates/account/email_confirm.html:23
 msgid "The email confirmation process for this email address has been terminated, please re-initiate"
 msgstr "O processo de confirmação de e-mail para este endereço de e-mail foi encerrado, reinicie"
 
+#: peeringdb_server/templates/account/email_confirm.html:23
+#: peeringdb_server/templates/admin/org_merge_tool.html:10
+#: peeringdb_server/templates/site/request-ownership.html:25
+#: peeringdb_server/templates/site/username-retrieve-complete.html:25
+#: peeringdb_server/templates/site/verification_banner.html:19
+#: peeringdb_server/templates/site/verification_banner.html:27
+#: peeringdb_server/templates/site/verification_banner.html:30
 msgid "here"
 msgstr "aqui"
 
+#: peeringdb_server/templates/account/login.html:7
 msgid "Please use"
 msgstr "Por favor, use"
 
+#: peeringdb_server/templates/account/login.html:7
 msgid "this page"
 msgstr "esta página"
 
+#: peeringdb_server/templates/account/login.html:7
 msgid "instead"
 msgstr "em vez de"
 
+#: peeringdb_server/templates/admin/change_list.html:7
+#: peeringdb_server/templates/admin/change_list.html:8
+#: peeringdb_server/templates/admin/change_list.html:9
+#: peeringdb_server/templates/admin/change_list.html:10
+#: peeringdb_server/templates/admin/change_list.html:11
+#: peeringdb_server/templates/admin/change_list.html:12
 #, python-format
 msgid "Show %(num)s rows"
 msgstr "Mostrar %(num)s linhas"
 
+#: peeringdb_server/templates/admin/change_list.html:12
 msgid "(Warning: potentially long load)"
 msgstr "(Aviso: carga potencialmente longa)"
 
+#: peeringdb_server/templates/admin/change_list_with_regex_search.html:5
 #, python-format
 msgid ""
 "\n"
@@ -1902,75 +1859,119 @@ msgstr ""
 "\n"
 "Para usar a <a href=“%(doc_url)s” target=“_blank”>regex search</a>, comece o termo de pesquisa com ^ e termine com $. <!-- lgtm[js/unsafe-external-link] -->\n"
 
+#: peeringdb_server/templates/admin/delete_confirmation.html:11
 msgid "WARNING! This object currently has DoTF protection:"
 msgstr "AVISO! Este objeto atualmente tem proteção DoTF:"
 
+#: peeringdb_server/templates/admin/delete_confirmation.html:15
+#: peeringdb_server/templates/admin/soft_delete.html:22
 msgid "As a superuser you may still proceed with the deletion."
 msgstr "Como superusuário, você ainda pode prosseguir com a exclusão."
 
+#: peeringdb_server/templates/admin/ixf_member_data_change_form.html:9
 msgid "Save and Apply"
 msgstr "Salvar e Aplicar"
 
+#: peeringdb_server/templates/admin/ixf_member_data_change_form.html:11
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:110
+#: peeringdb_server/templates/site/org_manage_keys.html:54
+#: peeringdb_server/templates/site/self-object-list.html:19
+#: peeringdb_server/templates/site/view.html:53
+#: peeringdb_server/templates/site/view.html:438
+#: peeringdb_server/templates/site/view_organization_assets.html:80
+#: peeringdb_server/templates/site/view_organization_tools.html:894
+#: peeringdb_server/templates/site/view_organization_tools.html:1049
 msgid "Save"
 msgstr "Salvar"
 
+#: peeringdb_server/templates/admin/ixf_member_data_change_form.html:12
 msgid "Save and continue editing"
 msgstr "Salvar e continuar editando"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:9
 msgid "Please proceed with caution, if you no one has explained this tool to you please obtain instructions from someone before proceeding"
 msgstr "Prossiga com cuidado, se ninguém lhe explicou esta ferramenta, obtenha instruções de alguém antes de prosseguir"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:10
 msgid "You may undo merges"
 msgstr "Você pode desfazer fusões"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:16
 msgid "Selected Organizations"
 msgstr "Organizações selecionadas"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:18
+#: peeringdb_server/templates/admin/org_merge_tool.html:29
+#: peeringdb_server/templates/site/advanced-search-campus.html:137
+#: peeringdb_server/templates/site/advanced-search-fac.html:114
+#: peeringdb_server/templates/site/advanced-search-ix.html:145
+#: peeringdb_server/templates/site/advanced-search-net.html:171
+#: peeringdb_server/templates/site/advanced-search-org.html:36
+#: peeringdb_server/templates/site/footer.html:34
 msgid "Search"
 msgstr "Pesquisar"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:19
 msgid "Organizations in this column will be merged into the organization in the right column. Click entries to remove from selection."
 msgstr "As organizações nesta coluna serão fundidas na organização na coluna da direita. Clique nas entradas para removê-las da seleção."
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:27
 msgid "Merge Into Organization"
 msgstr "Fundir na Organização"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:30
 msgid "Organizations in the left column will be merged into this organization"
 msgstr "As organizações na coluna da esquerda serão fundidas a esta organização"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:35
 msgid "Merge Organizations"
 msgstr "Fundir organização"
 
+#: peeringdb_server/templates/admin/org_merge_tool.html:41
 msgid "Merge Results"
 msgstr "Fundir resultados"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/prepare_command.html:18
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/preview_command.html:16
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/run_command.html:16
 msgid "Home"
 msgstr "Início"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/prepare_command.html:22
 msgid "Prepare"
 msgstr "Preparar"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/preview_command.html:20
+#: peeringdb_server/views.py:2326 peeringdb_server/views.py:2712
 msgid "Preview"
 msgstr "Visualização"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/run_command.html:20
 msgid "Result"
 msgstr "Resultado"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/run_command.html:41
 msgid "You can monitor progress and review the results here"
 msgstr "Você pode monitorar o progresso e revisar os resultados aqui"
 
+#: peeringdb_server/templates/admin/peeringdb_server/commandlinetool/run_command.html:41
 msgid "Command status"
 msgstr "Status do comando"
 
+#: peeringdb_server/templates/admin/soft_delete.html:7
 msgid "The following objects will be deleted:"
 msgstr "Os seguintes objetos serão excluídos:"
 
+#: peeringdb_server/templates/admin/soft_delete.html:18
 msgid "This object currently has DoTF protection:"
 msgstr "Este objeto atualmente tem proteção DoTF:"
 
+#: peeringdb_server/templates/apidocs/redoc.html:5
+#: peeringdb_server/templates/apidocs/swagger.html:5
 msgid "PeeringDB API Documentation"
 msgstr "Documentação da API PeeringDB"
 
+#: peeringdb_server/templates/email/notify-org-admin-flagged.txt:2
 #, python-format
 msgid ""
 "\n"
@@ -1991,849 +1992,1529 @@ msgstr ""
 "\n"
 "Você pode adicionar objetos à sua organização aqui: %(org_url)s\n"
 
+#: peeringdb_server/templates/email/notify-org-admin-merge.txt:2
 msgid "Merge Notification"
 msgstr "Notificação de fusão"
 
+#: peeringdb_server/templates/email/notify-org-admin-merge.txt:4
+#: peeringdb_server/templates/email/notify-org-admin-merge.txt:8
 msgid "ID"
 msgstr "ID"
 
+#: peeringdb_server/templates/email/notify-org-admin-merge.txt:6
 msgid "has been merged into"
 msgstr "foi fundido em"
 
+#: peeringdb_server/templates/email/notify-org-admin-merge.txt:11
 msgid "All merges are processed manually by peeringdb support staff. If you think this action has been executed in error please don't hesitate to contact peeringdb support at"
 msgstr "Todas as fusões são processadas manualmente pela equipe de suporte do peeringdb. Se você acha que esta ação foi executada por engano, não hesite em entrar em contato com o suporte do peeringdb em"
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-approved.txt:3
 #, python-format
 msgid "%(u_full_name)s's affiliation request to %(o_name)s has been APPROVED by %(admin_full_name)s."
 msgstr "A solicitação de afiliação de %(u_full_name)s a %(o_name)s foi APROVADA por %(admin_full_name)s."
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-approved.txt:7
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-denied.txt:7
 msgid "No further action is required on your part."
 msgstr "Nenhuma outra ação é necessária de sua parte."
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-approved.txt:9
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-denied.txt:9
 msgid "As the organization's administrator you may view your organization's user list here"
 msgstr "Como administrador da organização, você pode ver a lista de usuários da sua organização aqui"
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil-denied.txt:3
 #, python-format
 msgid "%(u_full_name)s's affiliation request to %(o_name)s has been DENIED by %(admin_full_name)s."
 msgstr "O pedido de afiliação de %(u_full_name)s a %(o_name)s foi NEGADO por %(admin_full_name)s."
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil.txt:3
 #, python-format
 msgid "User %(u_name)s (%(u_email)s) wishes to be affiliated to %(o_name)s."
 msgstr "O usuário %(u_name)s (%(u_email)s) deseja ser afiliado a %(o_name)s."
 
+#: peeringdb_server/templates/email/notify-org-admin-user-affil.txt:7
 msgid "As the organization's administrator you may approve or deny this request here"
 msgstr "Como administrador da organização, você pode aprovar ou negar esta solicitação aqui"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-affil.txt:3
 msgid "Ownership of organization was automatically granted to user"
 msgstr "A propriedade da organização foi concedida automaticamente ao usuário"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-affil.txt:5
+#: peeringdb_server/templates/site/view_organization_tools.html:784
+#: peeringdb_server/templates/site/view_organization_tools.html:849
 msgid "User"
 msgstr "Usuário"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-affil.txt:7
 msgid "AS"
 msgstr "AS"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-entity-creation.txt:4
 #, python-format
 msgid "Organization %(o_name)s (<a href=\"%(o_url)s\">%(o_id)s</a>) was automatically created during user '%(u_name)s's affiliation request to AS%(asn)s"
 msgstr "A organização %(o_name)s (<a href=“%(o_url)s”>%(o_id)s</a>) foi criada automaticamente durante a solicitação de afiliação do usuário ‘%(u_name)s para AS%(asn)s"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-entity-creation.txt:9
 #, python-format
 msgid "Network %(n_name)s (<a href=\"%(n_url)s\">%(n_id)s</a>) was automatically created during user '%(u_name)s's affiliation request to AS%(asn)s"
 msgstr "A rede %(n_name)s (<a href=“%(n_url)s”>%(n_id)s</a>) foi criada automaticamente durante a solicitação de afiliação do usuário ‘%(u_name)s ao AS%(asn)s"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-skipvq-org-key.txt:4
 #, python-format
 msgid "Organization API Key (prefix:%(prefix)s) with email '%(email)s' created Network %(n_name)s AS%(n_asn)s (<a href=\"%(n_url)s\">%(n_id)s</a>) under organization %(o_name)s (<a href=\"%(o_url)s\">%(o_id)s</a>)."
 msgstr "Chave de API da organização (prefixo:%(prefix)s) com e-mail ‘%(email)s’ Rede criada %(n_name)s AS%(n_asn)s (<a href=“%(n_url)s”>%(n_id)s</a>) sob a organização %(o_name)s (<a href=“%(o_url)s”>%(o_id)s</a>)."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-skipvq-org-key.txt:8
 msgid "As the key's email address was successfully matched against RiR entry data this network has skipped the verification queue."
 msgstr "Como o endereço de e-mail da chave foi comparado com os dados de entrada do RiR, esta rede pulou a fila de verificação."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-skipvq.txt:4
 #, python-format
 msgid "User '%(u_name)s' created Network %(n_name)s AS%(n_asn)s (<a href=\"%(n_url)s\">%(n_id)s</a>) under organization %(o_name)s (<a href=\"%(o_url)s\">%(o_id)s</a>)."
 msgstr "O usuário ‘%(u_name)s’ criou a rede %(n_name)s AS%(n_asn)s (<a href=“%(n_url)s”>%(n_id)s</a>) na organização %(o_name)s (<a href=“%(o_url)s”>%(o_id)s</a>)."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-asnauto-skipvq.txt:8
 msgid "As the user's email address was successfully matched against RiR entry data this network has skipped the verification queue."
 msgstr "Como o endereço de e-mail do usuário foi comparado com os dados de entrada do RiR, esta rede ignorou a fila de verificação."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:4
 #, python-format
 msgid "User %(u_name)s (%(u_email)s) wishes to be affiliated to ASN %(inst)s"
 msgstr "O usuário %(u_name)s (%(u_email)s) deseja se filiar ao ASN %(inst)s"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:8
 msgid "They also provided this organization name in their request"
 msgstr "Eles também forneceram o nome dessa organização em sua solicitação"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:10
 msgid "There was no entry in our database that matches that ASN, so it is likely that a network and organization for it will need to be created."
 msgstr "Não houve nenhuma entrada em nosso banco de dados que corresponda a esse ASN, portanto, é provável que seja necessário criar uma rede e uma organização para isso."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:12
 #, python-format
 msgid "User %(u_name)s (%(u_email)s) wishes to create an organization called %(o_name)s."
 msgstr "O usuário %(u_name)s (%(u_email)s) deseja criar uma organização chamada %(o_name)s."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:15
 msgid "There was no entry in our database that matches that organization name and no ASN was provided, so it is likely that this organization will need to be created."
 msgstr "Não houve nenhuma entrada em nosso banco de dados que corresponda a esse nome de organização e nenhum ASN foi fornecido, portanto, é provável que essa organização precise ser criada."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:17
 msgid "You may create a new organization here"
 msgstr "Você pode criar uma nova organização aqui"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:18
 msgid "You may create a new network here"
 msgstr "Você pode criar uma nova rede aqui"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:20
 #, python-format
 msgid "user %(user_name)s (%(u_email)s) wishes to be affiliated to Organization '%(o_name)s'"
 msgstr "usuário %(user_name)s (%(u_email)s) deseja ser afiliado à organização ‘%(o_name)s’"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:23
 msgid "They also provided this ASN in their request"
 msgstr "Eles também forneceram este ASN em sua solicitação"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:25
 msgid "ATTENTION: This is an ownership request, approving it will grant the user administration rights over the organization and any entities it owns."
 msgstr "ATENÇÃO: Esta é uma solicitação de propriedade, aprová-la concederá ao usuário direitos de administração sobre a organização e quaisquer entidades de sua propriedade."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:28
 msgid "These are the website addresses were able to derive from the organization and it's entities"
 msgstr "Estes são os endereços de sites que foram obtidos da organização e suas entidades"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:31
 msgid "These are the email addresses we could fetch from the ASNs belonging to this organization"
 msgstr "Estes são os endereços de e-mail que podemos obter dos ASNs pertencentes a esta organização"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:34
 msgid "The user is affiliated with other organizations"
 msgstr "O usuário é afiliado a outras organizações"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:37
 msgid "ADMIN"
 msgstr "ADMIN"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:39
 msgid "MEMBER"
 msgstr "MEMBRO"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:44
 msgid "Review Affiliation/Ownership Request"
 msgstr "Revisar solicitação de afiliação/propriedade"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-user-affil.txt:46
 msgid "Approve Ownership Request and Notify User"
 msgstr "Aprovar solicitação de propriedade e notificar o usuário"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:3
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:3
 #, python-format
 msgid "A new '%(entity_type_name)s' has been created and requires your approval."
 msgstr "Um novo ‘%(entity_type_name)s’ foi criado e requer sua aprovação."
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:8
 #, python-format
 msgid "This %(entity_type_name)s has been submitted as a suggestion and will need to be assigned the appropriate organization after review"
 msgstr "Este %(entity_type_name)s foi enviado como uma sugestão e precisará ser atribuído à organização apropriada após a revisão"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:14
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:14
 msgid "We retrieved the RiR entry for the specified ASN"
 msgstr "Recuperamos a entrada RiR para o ASN especificado"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:16
 msgid "but found no match with the requesting Organization API Key email. Here are the email addresses we gathered"
 msgstr "mas não encontrou nenhuma correspondência com o e-mail solicitante da chave de API da organização. Aqui estão os endereços de e-mail que reunimos"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:21
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:21
+#: peeringdb_server/templates/oauth2_provider/application_list.html:14
+#: peeringdb_server/templates/site/advanced-search-campus.html:12
+#: peeringdb_server/templates/site/advanced-search-campus.html:165
+#: peeringdb_server/templates/site/advanced-search-fac.html:12
+#: peeringdb_server/templates/site/advanced-search-fac.html:149
+#: peeringdb_server/templates/site/advanced-search-ix.html:11
+#: peeringdb_server/templates/site/advanced-search-ix.html:168
+#: peeringdb_server/templates/site/advanced-search-net.html:11
+#: peeringdb_server/templates/site/advanced-search-net.html:207
+#: peeringdb_server/templates/site/advanced-search-org.html:11
+#: peeringdb_server/templates/site/advanced-search-org.html:57
+#: peeringdb_server/templates/site/profile-security-keys.html:34
+#: peeringdb_server/templates/site/profile-security-keys.html:59
+#: peeringdb_server/templates/site/profile-security-keys.html:71
+#: peeringdb_server/templates/site/view_facility_bottom.html:80
+#: peeringdb_server/templates/site/view_network_bottom.html:38
+#: peeringdb_server/templates/site/view_network_bottom.html:149
+#: peeringdb_server/templates/site/view_organization_side.html:25
+#: peeringdb_server/templates/site/view_organization_side.html:40
+#: peeringdb_server/templates/site/view_organization_side.html:94
+#: peeringdb_server/templates/site/view_organization_side.html:108
+#: peeringdb_server/templates/site/view_organization_side.html:161
+#: peeringdb_server/templates/site/view_organization_side.html:176
+#: peeringdb_server/templates/site/view_organization_side.html:229
+#: peeringdb_server/templates/site/view_organization_side.html:240
+#: peeringdb_server/templates/site/view_organization_side.html:287
+#: peeringdb_server/templates/site/view_organization_side.html:298
+#: peeringdb_server/templates/site/view_organization_tools.html:117
+#: peeringdb_server/templates/site/view_organization_tools.html:313
+#: peeringdb_server/templates/site/view_organization_tools.html:505
+#: peeringdb_server/templates/site/view_organization_tools.html:701
+#: peeringdb_server/templates/site/view_organization_tools.html:743
+#: peeringdb_server/templates/site/view_organization_tools.html:783
+#: peeringdb_server/templates/site/view_organization_tools.html:848
+#: peeringdb_server/templates/site/view_suggest_fac.html:38
+#: peeringdb_server/templates/site/view_suggest_ix.html:38
+#: peeringdb_server/templates/site/view_suggest_net.html:38
+msgid "Name"
+msgstr "Nome"
+
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:22
 msgid "Requested by Organization API Key"
 msgstr "Solicitado pela chave de API da organização"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:24
 msgid "API key prefix"
 msgstr "Prefixo da chave de API"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:25
+#: peeringdb_server/templates/site/org_manage_keys.html:25
+#: peeringdb_server/templates/site/password-reset.html:19
+#: peeringdb_server/templates/site/register.html:64
+#: peeringdb_server/templates/site/username-retrieve.html:21
+#: peeringdb_server/templates/site/view_network_bottom.html:159
+#: peeringdb_server/templates/site/view_organization_tools.html:787
+#: peeringdb_server/templates/site/view_organization_tools.html:852
+msgid "Email"
+msgstr "Email"
+
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:27
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:24
 msgid "You can go to"
 msgstr "Você pode ir para"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq-org-key.txt:27
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:24
 msgid "to view and approve or deny this entry"
 msgstr "para ver e aprovar ou negar esta entrada"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:8
 #, python-format
 msgid "This %(entity_type_name)s has been submitted as a suggestion and will need to be assigned the aproporiate organization after review"
 msgstr "Este %(entity_type_name)s foi enviado como uma sugestão e precisará ser atribuído à organização apropriada após a revisão"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:16
 msgid "but found no match with the requesting user. Here are the email addresses we gathered"
 msgstr "mas não encontrou correspondência com o usuário solicitante. Aqui estão os endereços de e-mail que reunimos"
 
+#: peeringdb_server/templates/email/notify-pdb-admin-vq.txt:22
 msgid "Requested by user"
 msgstr "Solicitado pelo usuário"
 
+#: peeringdb_server/templates/email/notify-sponsorship-admin-expiration.txt:3
 #, python-format
 msgid "%(i_label)s level sponsorship from '%(io_name)s' expired on %(i_end_date)s."
 msgstr "O patrocínio de nível %(i_label)s de ‘%(io_name)s’ expirou em %(i_end_date)s."
 
+#: peeringdb_server/templates/email/notify-user-uoar-ownership-approved.txt:3
 #, python-format
 msgid "Your affiliation request to the Organization '%(o_name)s' and it's entities has been approved."
 msgstr "Sua solicitação de afiliação à organização ‘%(o_name)s’ e suas entidades foi aprovada."
 
+#: peeringdb_server/templates/email/notify-user-uoar-ownership-approved.txt:8
 msgid "This was the result of a manual review of your affiliation request to ASN"
 msgstr "This was the result of a manual review of your affiliation request to ASN"
 
+#: peeringdb_server/templates/email/notify-user-uoar-ownership-approved.txt:10
 msgid "This was the result of a manual review of your affiliation request to the organization or one of it's entities."
 msgstr "Este foi o resultado de uma revisão manual do seu pedido de afiliação à organização ou a uma das suas entidades."
 
+#: peeringdb_server/templates/email/notify-user-uoar-ownership-approved.txt:13
 msgid "You may view and edit your organization at"
 msgstr "Você pode visualizar e editar sua organização em"
 
+#: peeringdb_server/templates/email/notify-user-uoar-ownership-approved.txt:15
 msgid "If you have questions, please don't hesitate to contact peeringdb support at"
 msgstr "Se você tiver dúvidas, não hesite em entrar em contato com o suporte do peeringdb em"
 
+#: peeringdb_server/templates/email/password-reset.txt:2
 msgid "You initiated a password reset on PeeringDB 2 - Please follow the url below to reset your password."
 msgstr "Você iniciou uma redefinição de senha no PeeringDB 2 - Siga o URL abaixo para redefinir sua senha."
 
+#: peeringdb_server/templates/email/password-reset.txt:6
 msgid "If you did not initiate the password reset request, please ignore this email."
 msgstr "Se você não iniciou a solicitação de redefinição de senha, ignore este e-mail."
 
+#: peeringdb_server/templates/email/username-retrieve.txt:2
 msgid "You requested a username retrieval on PeeringDB for the email address"
 msgstr "Você solicitou uma recuperação de nome de usuário no PeeringDB para o endereço de e-mail"
 
+#: peeringdb_server/templates/email/username-retrieve.txt:3
 msgid "Please follow the url below to view any usernames associated with your email."
 msgstr "Siga o URL abaixo para ver os nomes de usuário associados ao seu e-mail."
 
+#: peeringdb_server/templates/email/username-retrieve.txt:7
 msgid "If you did not request username retrieval, you can ignore this email."
 msgstr "Se você não solicitou a recuperação do nome de usuário, pode ignorar este e-mail."
 
+#: peeringdb_server/templates/oauth2_provider/application_detail.html:7
 #, python-format
 msgid "This application is under %(org_name)s's management. All administrators of the organization may make changes to it."
 msgstr "Este aplicativo está sob o gerenciamento de %(org_name)s. Todos os administradores da organização podem fazer alterações nele."
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:9
 msgid "Your applications"
 msgstr "Suas aplicações"
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:24
+#: peeringdb_server/templates/site/org_manage_oauth.html:13
 msgid "Details"
 msgstr "Detalhes"
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:31
+#: peeringdb_server/templates/site/org_manage_oauth.html:19
 msgid "New Application"
 msgstr "Nova aplicação"
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:41
 msgid "No applications defined"
 msgstr "Nenhum aplicação definida"
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:41
 msgid "Click here"
 msgstr "Click aqui"
 
+#: peeringdb_server/templates/oauth2_provider/application_list.html:41
 msgid "if you want to register a new one"
 msgstr "se você quiser registrar um novo"
 
+#: peeringdb_server/templates/site/about.html:5
 msgid "Our Culture"
 msgstr "A nossa Cultura"
 
+#: peeringdb_server/templates/site/about.html:7
 msgid "PeeringDB, as the name suggests, was set up to facilitate peering between networks and peering coordinators. In recent years, the vision of PeeringDB has developed to keep up with the speed and diverse manner in which the Internet is growing. The database is no longer just for peering and peering related information. It now includes all types of interconnection data for networks, clouds, services, and enterprise, as well as interconnection facilities that are developing at the edge of the Internet."
 msgstr "PeeringDB, como o nome sugere, foi configurado para facilitar o peering entre redes e coordenadores de peering. Nos últimos anos, a visão do PeeringDB se desenvolveu para acompanhar a velocidade e a diversidade com que a Internet está crescendo. O banco de dados não é mais apenas para peering e informações relacionadas ao peering. Ele agora inclui todos os tipos de dados de interconexão para redes, nuvens, serviços e empresas, bem como recursos de interconexão que estão se desenvolvendo na borda da Internet."
 
+#: peeringdb_server/templates/site/about.html:9
 msgid "We believe in, and rely on the community to grow and improve the PeeringDB database. The volunteers who run the database are passionate about security, privacy, integrity, and validation of the data in the database. Even though PeeringDB is a freely available and public tool, users strictly adhere to the acceptable use policy, which prevents the database being used for commercial purposes and discourages unsolicited communications. This is largely policed by the community and has been very effective since PeeringDB was launched."
 msgstr "Acreditamos e contamos com a comunidade para crescer e melhorar o banco de dados PeeringDB. Os voluntários que administram o banco de dados são apaixonados por segurança, privacidade, integridade e validação dos dados no banco de dados. Embora o PeeringDB seja uma ferramenta pública e disponível gratuitamente, os usuários aderem estritamente à política de uso aceitável, o que impede que o banco de dados seja usado para fins comerciais e desencoraja comunicações não solicitadas. Isso é amplamente controlado pela comunidade e tem sido muito eficaz desde que o PeeringDB foi lançado."
 
+#: peeringdb_server/templates/site/about.html:10
 msgid "I’m a network operator. How can PeeringDB help me?"
 msgstr "Eu sou um operador de rede. Como o PeeringDB pode me ajudar?"
 
+#: peeringdb_server/templates/site/about.html:12
 msgid "Almost one-third of Autonomous System Numbers (ASNs) register their interconnection data in the PeeringDB database. That means, by using PeeringDB and adding your own interconnection data, you’ll be able to confidently find information about networks looking to interconnect, where and how to connect with them, and they’ll be able to find the same information about your network. Since the database is user-maintained and validated by our volunteers, you can trust that the information is accurate and up-to-date."
 msgstr "Quase um terço dos Números de Sistema Autônomo (ASNs) registram seus dados de interconexão no banco de dados PeeringDB. Isso significa que, usando o PeeringDB e adicionando seus próprios dados de interconexão, você poderá encontrar com segurança informações sobre redes que procuram se interconectar, onde e como se conectar a elas, e eles poderão encontrar as mesmas informações sobre sua rede . Como o banco de dados é mantido pelo usuário e validado por nossos voluntários, você pode confiar que as informações são precisas e atualizadas."
 
+#: peeringdb_server/templates/site/about.html:14
 msgid "This data will help you to accelerate the process of finding and connecting with other networks, while supporting a faster and more decisive deployment of your own network expansion and development plans."
 msgstr "Esses dados ajudarão você a acelerar o processo de localização e conexão com outras redes, ao mesmo tempo em que oferecem suporte a uma implantação mais rápida e decisiva de seus próprios planos de expansão e desenvolvimento de rede."
 
+#: peeringdb_server/templates/site/about.html:16
 msgid "I’m an Internet Exchange Point (IXP), data center or other interconnection facility. How can PeeringDB help me?"
 msgstr "Sou um Internet Exchange (IXP), centro de dados ou outra instalação de interconexão. Como o PeeringDB pode me ajudar?"
 
+#: peeringdb_server/templates/site/about.html:18
 msgid "IXPs and data center facilities can add to and maintain their information in the database, increasing visibility and their appeal to new and existing customers. If you’re in the database, this makes it much easier for networks to find crucial information about your services and the other networks present at your IXP or facilities."
 msgstr "Os IXPs e os PoPs do data center podem adicionar e manter suas informações no banco de dados, aumentando a visibilidade e seu apelo para clientes novos e existentes. Se você estiver no banco de dados, isso facilita muito para as redes encontrarem informações cruciais sobre seus serviços e as outras redes presentes em seu IXP ou instalações."
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:21
+#: peeringdb_server/templates/site/advanced-search-location.html:3
 msgid "Address"
 msgstr "Endereço"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:30
+#: peeringdb_server/templates/site/advanced-search-campus.html:169
+#: peeringdb_server/templates/site/advanced-search-fac.html:157
+#: peeringdb_server/templates/site/advanced-search-ix.html:20
+#: peeringdb_server/templates/site/advanced-search-ix.html:171
+#: peeringdb_server/templates/site/advanced-search-location.html:12
+#: peeringdb_server/templates/site/advanced-search-org.html:59
+#: peeringdb_server/templates/site/view_campus_side.html:27
+#: peeringdb_server/templates/site/view_campus_side.html:38
+#: peeringdb_server/templates/site/view_carrier_side.html:27
+#: peeringdb_server/templates/site/view_carrier_side.html:38
+#: peeringdb_server/templates/site/view_exchange_bottom.html:105
+#: peeringdb_server/templates/site/view_exchange_bottom.html:116
+#: peeringdb_server/templates/site/view_network_side.html:253
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_organization_side.html:29
+#: peeringdb_server/templates/site/view_organization_side.html:40
+#: peeringdb_server/templates/site/view_organization_side.html:165
+#: peeringdb_server/templates/site/view_organization_side.html:176
+#: peeringdb_server/templates/site/view_organization_tools.html:152
+#: peeringdb_server/templates/site/view_organization_tools.html:523
+#: peeringdb_server/templates/site/view_suggest_fac.html:73
+#: peeringdb_server/templates/site/view_suggest_ix.html:55
+#: peeringdb_server/views.py:2028 peeringdb_server/views.py:2153
+msgid "City"
+msgstr "Cidade"
+
+#: peeringdb_server/templates/site/advanced-search-campus.html:30
+#: peeringdb_server/templates/site/advanced-search-campus.html:173
+#: peeringdb_server/templates/site/advanced-search-fac.html:161
+#: peeringdb_server/templates/site/advanced-search-location.html:12
+#: peeringdb_server/templates/site/view_organization_tools.html:161
+#: peeringdb_server/templates/site/view_suggest_fac.html:82
+msgid "State"
+msgstr "Estado"
+
+#: peeringdb_server/templates/site/advanced-search-campus.html:30
+#: peeringdb_server/templates/site/advanced-search-location.html:12
 msgid "Postal"
 msgstr "Correio"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:55
+#: peeringdb_server/templates/site/advanced-search-campus.html:170
+#: peeringdb_server/templates/site/advanced-search-fac.html:158
+#: peeringdb_server/templates/site/advanced-search-ix.html:29
+#: peeringdb_server/templates/site/advanced-search-ix.html:170
+#: peeringdb_server/templates/site/advanced-search-location.html:37
+#: peeringdb_server/templates/site/advanced-search-org.html:58
+#: peeringdb_server/templates/site/view_campus_side.html:24
+#: peeringdb_server/templates/site/view_campus_side.html:38
+#: peeringdb_server/templates/site/view_carrier_side.html:24
+#: peeringdb_server/templates/site/view_carrier_side.html:38
+#: peeringdb_server/templates/site/view_exchange_bottom.html:102
+#: peeringdb_server/templates/site/view_exchange_bottom.html:116
+#: peeringdb_server/templates/site/view_network_side.html:252
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_organization_side.html:28
+#: peeringdb_server/templates/site/view_organization_side.html:40
+#: peeringdb_server/templates/site/view_organization_side.html:164
+#: peeringdb_server/templates/site/view_organization_side.html:176
+#: peeringdb_server/templates/site/view_organization_tools.html:180
+#: peeringdb_server/templates/site/view_organization_tools.html:531
+#: peeringdb_server/templates/site/view_suggest_fac.html:101
+#: peeringdb_server/templates/site/view_suggest_ix.html:64
+#: peeringdb_server/views.py:2158
+msgid "Country"
+msgstr "País"
+
+#: peeringdb_server/templates/site/advanced-search-campus.html:55
+#: peeringdb_server/templates/site/advanced-search-campus.html:75
+#: peeringdb_server/templates/site/advanced-search-ix.html:29
+#: peeringdb_server/templates/site/advanced-search-ix.html:41
+#: peeringdb_server/templates/site/advanced-search-ix.html:101
+#: peeringdb_server/templates/site/advanced-search-ix.html:112
+#: peeringdb_server/templates/site/advanced-search-ix.html:124
+#: peeringdb_server/templates/site/advanced-search-location.html:37
+#: peeringdb_server/templates/site/advanced-search-location.html:55
+#: peeringdb_server/templates/site/advanced-search-net.html:20
+#: peeringdb_server/templates/site/advanced-search-net.html:31
+#: peeringdb_server/templates/site/advanced-search-net.html:43
+#: peeringdb_server/templates/site/advanced-search-net.html:101
+#: peeringdb_server/templates/site/advanced-search-net.html:113
+#: peeringdb_server/templates/site/advanced-search-org-present.html:3
 msgid "click to select multiple"
 msgstr "clique para selecionar vários"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:75
+#: peeringdb_server/templates/site/advanced-search-ix.html:41
+#: peeringdb_server/templates/site/advanced-search-location.html:55
+#: peeringdb_server/templates/site/view_organization_tools.html:542
+#: peeringdb_server/templates/site/view_suggest_ix.html:75
+#: peeringdb_server/views.py:1744 peeringdb_server/views.py:2165
+msgid "Continental Region"
+msgstr "Região continental"
+
+#: peeringdb_server/templates/site/advanced-search-campus.html:88
+#: peeringdb_server/templates/site/advanced-search-location.html:68
 msgid "Within Distance"
 msgstr "Dentro da distância"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:105
 msgid "Additional filters are available to authenticated users, and you are currently not logged in."
 msgstr "Filtros adicionais estão disponíveis para usuários autenticados e você não está conectado no momento."
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:107
 msgid "Additional filters are available to verified users, and you are currently not affiliated with any organizations."
 msgstr "Filtros adicionais estão disponíveis para usuários verificados e você não é afiliado a nenhuma organização."
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:136
+#: peeringdb_server/templates/site/advanced-search-fac.html:113
+#: peeringdb_server/templates/site/advanced-search-ix.html:144
+#: peeringdb_server/templates/site/advanced-search-net.html:170
+#: peeringdb_server/templates/site/advanced-search-org.html:35
 msgid "Reset"
 msgstr "Redefinir"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:166
+#: peeringdb_server/templates/site/advanced-search-fac.html:150
 msgid "Management"
 msgstr "Gerenciamento"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:174
+#: peeringdb_server/templates/site/advanced-search-fac.html:162
 msgid "Postal Code"
 msgstr "Código postal"
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:180
+#: peeringdb_server/templates/site/advanced-search-fac.html:172
+#: peeringdb_server/templates/site/advanced-search-ix.html:177
+#: peeringdb_server/templates/site/advanced-search-net.html:231
+#: peeringdb_server/templates/site/advanced-search-org.html:64
 msgid "No search results."
 msgstr "Nenhum resultado de pesquisa."
 
+#: peeringdb_server/templates/site/advanced-search-campus.html:185
+#: peeringdb_server/templates/site/advanced-search-fac.html:181
+#: peeringdb_server/templates/site/advanced-search-ix.html:186
+#: peeringdb_server/templates/site/advanced-search-net.html:240
+#: peeringdb_server/templates/site/advanced-search-org.html:73
 #, python-format
 msgid "...More than %(row_limit)s entries matched your query, refine your request..."
 msgstr "…Mais de %(row_limit)s entradas corresponderam à sua consulta, refine sua solicitação…"
 
+#: peeringdb_server/templates/site/advanced-search-fac.html:48
+#: peeringdb_server/templates/site/advanced-search-fac.html:153
 msgid "CLLI"
 msgstr "CLLI"
 
+#: peeringdb_server/templates/site/advanced-search-fac.html:58
+#: peeringdb_server/templates/site/advanced-search-fac.html:154
+#: peeringdb_server/templates/site/view_organization_tools.html:199
+#: peeringdb_server/templates/site/view_suggest_fac.html:120
+#: peeringdb_server/views.py:1769
+msgid "NPA-NXX"
+msgstr "NPA-NXX"
+
+#: peeringdb_server/templates/site/advanced-search-fac.html:68
+#: peeringdb_server/templates/site/view_organization_tools.html:260
+#: peeringdb_server/views.py:1823
+msgid "Property"
+msgstr "Propriedade"
+
+#: peeringdb_server/templates/site/advanced-search-fac.html:74
+#: peeringdb_server/templates/site/advanced-search-fac.html:87
+#: peeringdb_server/templates/site/advanced-search-fac.html:99
+#: peeringdb_server/templates/site/advanced-search-org-present.html:7
 msgid "Does not matter"
 msgstr "Não importa"
 
+#: peeringdb_server/templates/site/advanced-search-fac.html:81
+#: peeringdb_server/templates/site/view_organization_tools.html:269
+#: peeringdb_server/views.py:1831
+msgid "Diverse Serving Substations"
+msgstr "Subestações de serviços diversos"
+
+#: peeringdb_server/templates/site/advanced-search-fac.html:93
+#: peeringdb_server/templates/site/view_organization_tools.html:278
+#: peeringdb_server/views.py:1843
+msgid "Available Voltage Services"
+msgstr "Serviços de tensão disponíveis"
+
+#: peeringdb_server/templates/site/advanced-search-fac.html:165
+#: peeringdb_server/templates/site/advanced-search-ix.html:172
+#: peeringdb_server/templates/site/advanced-search.html:16
+#: peeringdb_server/templates/site/footer.html:56
+#: peeringdb_server/templates/site/index.html:70
+#: peeringdb_server/templates/site/search_result.html:76
+#: peeringdb_server/templates/site/search_result_frame.html:9
+#: peeringdb_server/templates/site/view_facility_bottom.html:23
+#: peeringdb_server/templates/site/view_facility_side.html:8
+#: peeringdb_server/templates/site/view_organization_side.html:86
+msgid "Networks"
+msgstr "Redes"
+
+#: peeringdb_server/templates/site/advanced-search-ix.html:79
 msgid "IP Block"
 msgstr "Bloco de IP"
 
+#: peeringdb_server/templates/site/advanced-search-ix.html:88
 msgid "Capacity"
 msgstr "Capacidade"
 
+#: peeringdb_server/templates/site/advanced-search-ix.html:101
+#: peeringdb_server/templates/site/advanced-search-ix.html:169
+#: peeringdb_server/templates/site/view_organization_tools.html:552
+#: peeringdb_server/templates/site/view_suggest_ix.html:85
+#: peeringdb_server/views.py:2172
+msgid "Media Type"
+msgstr "Tipo de mídia"
+
+#: peeringdb_server/templates/site/advanced-search-ix.html:112
+#: peeringdb_server/views.py:2179
+msgid "Service Level"
+msgstr "Níveis de serviço"
+
+#: peeringdb_server/templates/site/advanced-search-ix.html:124
+#: peeringdb_server/views.py:2186
+msgid "Terms"
+msgstr "Termos"
+
+#: peeringdb_server/templates/site/advanced-search-location.html:85
 msgid "Additional filters are available to authenticated users and you are currently not logged in."
 msgstr "Filtros adicionais estão disponíveis para usuários autenticados e você não está conectado no momento."
 
+#: peeringdb_server/templates/site/advanced-search-location.html:87
 msgid "Additional filters are available to verified users and you are currently not affiliated with any organizations."
 msgstr "Filtros adicionais estão disponíveis para usuários verificados e você atualmente não é afiliado a nenhuma organização."
 
+#: peeringdb_server/templates/site/advanced-search-net-present.html:3
 msgid "Network Presence"
 msgstr "Network Presence"
 
+#: peeringdb_server/templates/site/advanced-search-net-present.html:7
 msgid "Search networks ..."
 msgstr "Pesquisar redes…"
 
+#: peeringdb_server/templates/site/advanced-search-net-present.html:26
 msgid "All present"
 msgstr "Todos presentes"
 
+#: peeringdb_server/templates/site/advanced-search-net-present.html:27
 msgid "Any present"
 msgstr "Qualquer presente"
 
+#: peeringdb_server/templates/site/advanced-search-net-present.html:28
 msgid "None present"
 msgstr "Nenhum presente"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:20
+#: peeringdb_server/templates/site/advanced-search-net.html:215
+#: peeringdb_server/templates/site/view_organization_tools.html:348
+#: peeringdb_server/templates/site/view_suggest_net.html:73
+#: peeringdb_server/views.py:2554
+msgid "Network Type"
+msgstr "Tipo de rede"
+
+#: peeringdb_server/templates/site/advanced-search-net.html:31
+#: peeringdb_server/templates/site/advanced-search-net.html:219
+#: peeringdb_server/templates/site/view_organization_tools.html:357
+#: peeringdb_server/templates/site/view_suggest_net.html:82
+#: peeringdb_server/views.py:2581
+msgid "Traffic Levels"
+msgstr "Níveis de tráfego"
+
+#: peeringdb_server/templates/site/advanced-search-net.html:43
+#: peeringdb_server/templates/site/advanced-search-net.html:220
 msgid "Traffic Ratio"
 msgstr "Taxa de Tráfego"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:81
+#: peeringdb_server/templates/site/advanced-search-net.html:211
+#: peeringdb_server/templates/site/advanced-search-org.html:24
+#: peeringdb_server/templates/site/profile-affiliate.html:77
+#: peeringdb_server/templates/site/view_exchange_side.html:22
+#: peeringdb_server/templates/site/view_exchange_side.html:40
+#: peeringdb_server/templates/site/view_facility_side.html:19
+#: peeringdb_server/templates/site/view_facility_side.html:27
+#: peeringdb_server/templates/site/view_network_side.html:28
+#: peeringdb_server/templates/site/view_network_side.html:46
+#: peeringdb_server/templates/site/view_network_side.html:249
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_organization_side.html:97
+#: peeringdb_server/templates/site/view_organization_side.html:108
+#: peeringdb_server/templates/site/view_organization_tools.html:330
+#: peeringdb_server/templates/site/view_suggest_net.html:55
+#: peeringdb_server/views.py:2523
 msgid "ASN"
 msgstr "ASN"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:91
+#: peeringdb_server/templates/site/view_organization_tools.html:339
+#: peeringdb_server/templates/site/view_suggest_net.html:64
+#: peeringdb_server/views.py:2530
+msgid "IRR as-set/route-set"
+msgstr "IRR as-set/route-set"
+
+#: peeringdb_server/templates/site/advanced-search-net.html:101
 msgid "General Peering Policy"
 msgstr "Política geral de peering"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:113
+#: peeringdb_server/templates/site/view_organization_tools.html:375
+#: peeringdb_server/templates/site/view_suggest_net.html:100
+#: peeringdb_server/views.py:2597
+msgid "Geographic Scope"
+msgstr "Alcance geográfico"
+
+#: peeringdb_server/templates/site/advanced-search-net.html:125
 msgid "Exchange Presence"
 msgstr "Presença do Exchange"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:125
 msgid "Search for networks that are present at one exchange and absent at another exchange"
 msgstr "Pesquise por redes que estão presentes em uma troca e ausentes em outra troca"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:127
+#: peeringdb_server/templates/site/advanced-search-org-present.html:8
 msgid "Present"
 msgstr "Presente"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:135
 msgid "Absent"
 msgstr "Ausente"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:146
 msgid "Facility Presence"
 msgstr "Presença do PoP"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:146
 msgid "Search for networks that are present at one Facility, but absent from another facility"
 msgstr "Pesquise redes que estão presentes em uma instalação, mas ausentes em outra instalação"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:208
 msgid "Also known as"
 msgstr "Também conhecido como"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:212
+#: peeringdb_server/templates/site/view_organization_tools.html:415
+#: peeringdb_server/templates/site/view_suggest_net.html:140
+#: peeringdb_server/views.py:2728
+msgid "General Policy"
+msgstr "Política geral"
+
+#: peeringdb_server/templates/site/advanced-search-net.html:216
 msgid "Network Scope"
 msgstr "Escopo da rede"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:223
+#: peeringdb_server/templates/site/advanced-search.html:13
+#: peeringdb_server/templates/site/footer.html:55
+#: peeringdb_server/templates/site/index.html:59
+#: peeringdb_server/templates/site/search_result.html:63
+#: peeringdb_server/templates/site/search_result_frame.html:5
+#: peeringdb_server/templates/site/view_facility_bottom.html:9
+#: peeringdb_server/templates/site/view_organization_side.html:153
 msgid "Exchanges"
 msgstr "Exchanges"
 
+#: peeringdb_server/templates/site/advanced-search-net.html:224
+#: peeringdb_server/templates/site/advanced-search.html:19
+#: peeringdb_server/templates/site/footer.html:57
+#: peeringdb_server/templates/site/index.html:81
+#: peeringdb_server/templates/site/search_result.html:90
+#: peeringdb_server/templates/site/search_result_frame.html:13
+#: peeringdb_server/templates/site/view_campus_side.html:13
+#: peeringdb_server/templates/site/view_carrier_side.html:13
+#: peeringdb_server/templates/site/view_organization_side.html:17
+msgid "Facilities"
+msgstr "PoPs"
+
+#: peeringdb_server/templates/site/advanced-search-org-present.html:3
 msgid "My organization presence"
 msgstr "Minha presença na organização"
 
+#: peeringdb_server/templates/site/advanced-search-org-present.html:9
 msgid "Not present"
 msgstr "Não presente"
 
+#: peeringdb_server/templates/site/advanced-search.html:22
+#: peeringdb_server/templates/site/footer.html:64
+#: peeringdb_server/templates/site/search_result.html:103
+#: peeringdb_server/templates/site/search_result_frame.html:17
+msgid "Organizations"
+msgstr "Organizações"
+
+#: peeringdb_server/templates/site/advanced-search.html:25
+#: peeringdb_server/views.py:1751
+msgid "Campus"
+msgstr "Campus"
+
+#: peeringdb_server/templates/site/beta_banner.html:7
 msgid "This is a beta/testing instance of PeeringDB. Some features may work differently than production. Do not store data here that you intend to keep"
 msgstr "Esta é uma instância beta/de teste do PeeringDB. Alguns recursos podem funcionar de maneira diferente da produção. Não armazene aqui dados que você pretende manter"
 
+#: peeringdb_server/templates/site/beta_banner.html:11
 #, python-format
 msgid "- all data will be refreshed from production at %(dt)sZ"
 msgstr "- todos os dados serão atualizados da produção em %(dt)sZ"
 
+#: peeringdb_server/templates/site/entity_create.html:5
 msgid "Only use this if you own the facility"
 msgstr "Só use isso se você for o proprietário do PoP"
 
+#: peeringdb_server/templates/site/entity_create.html:7
 msgid "Only use this if you own the exchange"
 msgstr "Só use isso se você for o proprietário do Exchange"
 
+#: peeringdb_server/templates/site/entity_create.html:9
 msgid "Only use this if you own the carrier"
 msgstr "Só use isso se você for o proprietário da operadora"
 
+#: peeringdb_server/templates/site/entity_create.html:11
 msgid "Only use this if you own the campus"
 msgstr "Só use isso se você for o proprietário do campus"
 
+#: peeringdb_server/templates/site/entity_create.html:16
 #, python-format
 msgid "Add a new %(entity_name)s to your Organization. Note that the newly created %(entity_name)s will need to be approved by PeeringDB staff before it will appear in the search results or the API listings"
 msgstr "Adicione um novo %(entity_name)s à sua organização. Observe que os %(entity_name)s recém-criados precisarão ser aprovados pela equipe do PeeringDB antes de aparecerem nos resultados da pesquisa ou nas listagens da API"
 
+#: peeringdb_server/templates/site/entity_create.html:21
 #, python-format
 msgid "Add a new %(entity_name)s to your Organization. Note that your campus will not be visible to other users until it has at least <strong>2</strong> facilities in it."
 msgstr "Adicione um novo %(entity_name)s à sua organização. Observe que seu campus não ficará visível para outros usuários até que tenha pelo menos <strong>2</strong> instalações nele."
 
+#: peeringdb_server/templates/site/entity_create.html:26
 msgid "Add a new carrier to your Organization."
 msgstr "Adicione uma nova operadora à sua organização."
 
+#: peeringdb_server/templates/site/entity_create.html:31
 msgid "To be listed as a Facility in PeeringDB we would expect that you offer colocation, data center and/or meet-me-room services to the public."
 msgstr "Para ser listado como um PoP no PeeringDB, esperamos que você ofereça serviços de colocation, data center e/ou sala de reuniões ao público."
 
+#: peeringdb_server/templates/site/entity_create.html:38
 msgid "To be listed as an Internet Exchange in PeeringDB we would expect that you meet the following criteria:"
 msgstr "Para ser listado como um Internet Exchange no PeeringDB, esperamos que você atenda aos seguintes critérios:"
 
+#: peeringdb_server/templates/site/entity_create.html:42
+#: peeringdb_server/templates/site/entity_suggest.html:24
 msgid "An Internet Exchange Point (IXP) is a network facility that enables the interconnection of more than two independent Autonomous Systems, primarily for the purpose of facilitating the exchange of Internet traffic."
 msgstr "Um Internet Exchange (IXP) é uma instalação de rede que permite a interconexão de mais de dois Sistemas Autônomos independentes, principalmente com o objetivo de facilitar a troca de tráfego de Internet."
 
+#: peeringdb_server/templates/site/entity_create.html:46
+#: peeringdb_server/templates/site/entity_suggest.html:28
 msgid "An IXP provides interconnection only for Autonomous Systems. An IXP does not require the Internet traffic passing between any pair of participating Autonomous Systems to pass through any third Autonomous System, nor does it alter or otherwise interfere with such traffic"
 msgstr "Um IXP fornece interconexão apenas para Sistemas Autônomos. Um IXP não exige que o tráfego da Internet que passa entre qualquer par de Sistemas Autônomos participantes passe por qualquer terceiro Sistema Autônomo, nem altera ou interfere de outra forma com esse tráfego"
 
+#: peeringdb_server/templates/site/entity_create.html:54
 msgid "Submit"
 msgstr "Submeter"
 
+#: peeringdb_server/templates/site/entity_suggest.html:4
 #, python-format
 msgid "Suggest %(entity_name)s to be added to the database. Your suggestion will be reviewed by the PeeringDB Administration Committee. It will then either be finalized and entered into the database, or declined. No further action is required on your part."
 msgstr "Sugira que %(entity_name)s sejam adicionados ao banco de dados. Sua sugestão será analisada pelo Comitê de administração do PeeringDB. Ele será finalizado e inserido no banco de dados ou recusado. Nenhuma outra ação é necessária de sua parte."
 
+#: peeringdb_server/templates/site/entity_suggest.html:9
 msgid "In order to be approved we would expect that the suggested Facility offers colocation, data center and/or meet-me-room services to the public."
 msgstr "Para ser aprovado, esperamos que a Instalação sugerida ofereça colocation, data center e/ou serviços de reunião ao público."
 
+#: peeringdb_server/templates/site/entity_suggest.html:14
 msgid "Only use this if you don't own the Facility. If you own it, please use \"Add Facility\" under your organization record."
 msgstr "Só use isso se você não for o proprietário da Instalação. Se você for o proprietário, use “Adicionar PoP” no registro da sua organização."
 
+#: peeringdb_server/templates/site/entity_suggest.html:20
 msgid "In order to be approved we would expect that the suggested Exchange meets the following criteria:"
 msgstr "Para ser aprovado, esperamos que a troca sugerida atenda aos seguintes critérios:"
 
+#: peeringdb_server/templates/site/entity_suggest.html:35
 msgid "Suggest"
 msgstr "Sugestão"
 
+#: peeringdb_server/templates/site/error.html:24
 msgid "404 - Not Found"
 msgstr "404 - não encontrado"
 
+#: peeringdb_server/templates/site/error.html:25
 msgid "The page you requested does not exist."
 msgstr "A página solicitada não existe."
 
+#: peeringdb_server/templates/site/error.html:27
 msgid "403 - Forbidden"
 msgstr "403 - Proibido"
 
+#: peeringdb_server/templates/site/error.html:28
 msgid "You don't have permissions to view this page."
 msgstr "Você não tem permissão para visualizar esta página."
 
+#: peeringdb_server/templates/site/error.html:31
 msgid "Take me home"
 msgstr "Me leve para o início"
 
+#: peeringdb_server/templates/site/footer.html:9
 msgid "All Rights Reserved. By using this service, you agree to adhere to our"
 msgstr "Todos os direitos reservados. Ao usar este serviço, você concorda em aderir aos nossos"
 
+#: peeringdb_server/templates/site/footer.html:10
 msgid "AUP"
 msgstr "AUP"
 
+#: peeringdb_server/templates/site/footer.html:13
 msgid "Privacy Policy"
 msgstr "Email da Política"
 
+#: peeringdb_server/templates/site/footer.html:28
 msgid "About"
 msgstr "Sobre"
 
+#: peeringdb_server/templates/site/footer.html:31
+#: peeringdb_server/templates/site/header.html:151
+#: peeringdb_server/templates/site/profile-security-keys.html:64
 msgid "Register"
 msgstr "Registar"
 
+#: peeringdb_server/templates/site/footer.html:37
+#: peeringdb_server/templates/site/sponsorships.html:12
+#: peeringdb_server/templates/site/sponsorships.html:29
+#: peeringdb_server/templates/site/sponsorships.html:46
+#: peeringdb_server/templates/site/sponsorships.html:63
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
+#: peeringdb_server/templates/site/footer.html:40
 msgid "Resources"
 msgstr "Recursos"
 
+#: peeringdb_server/templates/site/footer.html:41
 msgid "API"
 msgstr "API"
 
+#: peeringdb_server/templates/site/footer.html:42
 msgid "Documentation"
 msgstr "Documentação"
 
+#: peeringdb_server/templates/site/footer.html:43
 msgid "Release Notes"
 msgstr "Favor usar"
 
+#: peeringdb_server/templates/site/footer.html:44
 msgid "FAQ"
 msgstr "FAQ"
 
+#: peeringdb_server/templates/site/footer.html:45
 msgid "Governance"
 msgstr "Governança"
 
+#: peeringdb_server/templates/site/footer.html:48
 msgid "Contact Us"
 msgstr "Contate-nos"
 
+#: peeringdb_server/templates/site/footer.html:53
 msgid "Global System Statistics"
 msgstr "Estatísticas globais do sistema"
 
+#: peeringdb_server/templates/site/footer.html:58
+#: peeringdb_server/templates/site/view_organization_side.html:279
+msgid "Campuses"
+msgstr "Campuses"
+
+#: peeringdb_server/templates/site/footer.html:59
+#: peeringdb_server/templates/site/index.html:92
+#: peeringdb_server/templates/site/view_facility_bottom.html:62
+#: peeringdb_server/templates/site/view_organization_side.html:221
+msgid "Carriers"
+msgstr "Operadoras"
+
+#: peeringdb_server/templates/site/footer.html:60
 msgid "Connections to Exchanges"
 msgstr "Conexões com Exchanges"
 
+#: peeringdb_server/templates/site/footer.html:61
 msgid "Connections to Facilities"
 msgstr "Conexões com PoPs"
 
+#: peeringdb_server/templates/site/footer.html:62
 msgid "Automated Networks"
 msgstr "Redes Automatizadas"
 
+#: peeringdb_server/templates/site/footer.html:63
 msgid "Registered Users"
 msgstr "Usuários registrados"
 
+#: peeringdb_server/templates/site/header.html:104
 msgid "Search here for a network, IX, or facility."
 msgstr "Pesquise aqui uma rede, IX ou instalação."
 
+#: peeringdb_server/templates/site/header.html:109
 msgid "Advanced Search"
 msgstr "Busca Avançada"
 
+#: peeringdb_server/templates/site/header.html:114
 msgid "v2 Search (Beta)"
 msgstr "pesquisa v2 (Beta)"
 
+#: peeringdb_server/templates/site/header.html:128
 msgid "pending"
 msgstr "pendente"
 
+#: peeringdb_server/templates/site/header.html:130
 msgid "unverified"
 msgstr "não verificado"
 
+#: peeringdb_server/templates/site/header.html:144
+#: peeringdb_server/templates/site/search_result.html:133
+#: peeringdb_server/templates/site/search_result_frame.html:35
 msgid "Suggest Facility"
 msgstr "Sugerir PoP"
 
+#: peeringdb_server/templates/site/header.html:146
 msgid "Profile"
 msgstr "Perfil"
 
+#: peeringdb_server/templates/site/header.html:147
 msgid "Logout"
 msgstr "Logout"
 
+#: peeringdb_server/templates/site/header.html:151
+#: peeringdb_server/templates/site/view_campus_side.html:38
+#: peeringdb_server/templates/site/view_carrier_side.html:38
+#: peeringdb_server/templates/site/view_exchange_bottom.html:116
+#: peeringdb_server/templates/site/view_exchange_side.html:41
+#: peeringdb_server/templates/site/view_facility_bottom.html:31
+#: peeringdb_server/templates/site/view_facility_side.html:27
+#: peeringdb_server/templates/site/view_network_side.html:46
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_organization_side.html:40
+#: peeringdb_server/templates/site/view_organization_side.html:108
+#: peeringdb_server/templates/site/view_organization_side.html:176
 msgid "or"
 msgstr "ou"
 
+#: peeringdb_server/templates/site/header.html:151
+#: peeringdb_server/templates/two_factor/core/login.html:7
 msgid "Login"
 msgstr "Login"
 
+#: peeringdb_server/templates/site/index.html:37
 msgid "The Interconnection Database"
 msgstr "O banco de dados de interconexão"
 
+#: peeringdb_server/templates/site/index.html:40
 msgid "Join. Search. Grow your network."
 msgstr "Juntar. Procurar. Aumente sua rede."
 
+#: peeringdb_server/templates/site/index.html:42
 msgid "PeeringDB is a freely available, user-maintained, database of networks, and the go-to location for interconnection data. The database facilitates the global interconnection of networks at Internet Exchange Points (IXPs), data centers, and other interconnection facilities, and is the first stop in making interconnection decisions."
 msgstr "O PeeringDB é um banco de dados de redes disponível gratuitamente e mantido pelo usuário e o local ideal para dados de interconexão. O banco de dados facilita a interconexão global de redes em Internet Exchanges (IXPs), centros de dados (DCs) e outros PoPs de interconexão e é a primeira parada na tomada de decisões de interconexão."
 
+#: peeringdb_server/templates/site/index.html:47
 msgid "The database is a non-profit, community-driven initiative run and promoted by volunteers. It is a public tool for the growth and good of the Internet. Join the community and support the continued development of the Internet."
 msgstr "O banco de dados é uma iniciativa sem fins lucrativos, dirigida pela comunidade, administrada e promovida por voluntários. É uma ferramenta pública para o crescimento e o bem da Internet. Junte-se à comunidade e apoie o desenvolvimento contínuo da Internet."
 
+#: peeringdb_server/templates/site/index.html:52
 msgid "Learn more"
 msgstr "Saber mais"
 
+#: peeringdb_server/templates/site/index.html:52
 msgid "about"
 msgstr "sobre"
 
+#: peeringdb_server/templates/site/index.html:52
 msgid "register"
 msgstr "registrar"
 
+#: peeringdb_server/templates/site/index.html:56
 msgid "Most Recent Updates"
 msgstr "Atualizações mais recentes"
 
+#: peeringdb_server/templates/site/maintenance.html:4
 msgid "Maintenance Mode"
 msgstr "Modo de manutenção"
 
+#: peeringdb_server/templates/site/maintenance.html:5
 msgid "The site is currently in maintenance mode, during which this action is disabled, please try again in a few minutes"
 msgstr "O site está atualmente em modo de manutenção, durante o qual esta ação está desativada, tente novamente em alguns minutos"
 
+#: peeringdb_server/templates/site/oauth-login.html:6
 msgid "Login with oAuth"
 msgstr "Login com oAuth"
 
+#: peeringdb_server/templates/site/oauth-login.html:8
 msgid "Login with your Google account"
 msgstr "Login com sua conta do Google"
 
+#: peeringdb_server/templates/site/oauth-login.html:9
 msgid "Login with your Facebook account"
 msgstr "Login com sua conta do Facebook"
 
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:5
 msgid "Here you can grant permissions to your organization API keys. In case your recently added api key does not show up in this listing, please reload the page."
 msgstr "Aqui você pode conceder permissões às chaves de API da sua organização. Caso sua chave de API adicionada recentemente não apareça nesta listagem, recarregue a página."
 
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:25
+#: peeringdb_server/templates/site/register.html:95
+#: peeringdb_server/templates/site/view_organization_tools.html:967
 msgid "Create"
 msgstr "Criar"
 
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:28
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:250
+#: peeringdb_server/templates/site/view_organization_tools.html:970
 msgid "Update"
 msgstr "Atualizar"
 
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:31
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:229
+#: peeringdb_server/templates/site/view_organization_tools.html:973
 msgid "Delete"
 msgstr "Deletar"
 
+#: peeringdb_server/templates/site/org_manage_key_permissions.html:97
+#: peeringdb_server/templates/site/org_manage_keys.html:107
+#: peeringdb_server/templates/site/profile-api-keys.html:68
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:88
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:168
+#: peeringdb_server/templates/site/view_organization_tools.html:1036
 msgid "Add"
 msgstr "Adicionar"
 
+#: peeringdb_server/templates/site/org_manage_keys.html:4
 msgid "Here you can create new API keys for your organization or revoke existing keys."
 msgstr "Aqui você pode criar novas chaves de API para sua organização ou revogar chaves existentes."
 
+#: peeringdb_server/templates/site/org_manage_keys.html:19
+#: peeringdb_server/templates/site/profile-api-keys.html:19
+#: peeringdb_server/templates/site/view_exchange_bottom.html:18
+#: peeringdb_server/templates/site/view_exchange_bottom.html:67
+#: peeringdb_server/templates/site/view_organization_tools.html:657
+#: peeringdb_server/templates/site/view_suggest_ix.html:154
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: peeringdb_server/templates/site/org_manage_keys.html:22
+#: peeringdb_server/templates/site/profile-api-keys.html:22
+msgid "Description"
+msgstr "Descrição"
+
+#: peeringdb_server/templates/site/org_manage_keys.html:50
+#: peeringdb_server/templates/site/view.html:49
+#: peeringdb_server/templates/site/view_organization_assets.html:76
 msgid "Edit"
 msgstr "Editar"
 
+#: peeringdb_server/templates/site/org_manage_keys.html:53
+#: peeringdb_server/templates/site/profile-affiliate.html:20
+#: peeringdb_server/templates/site/view.html:52
+#: peeringdb_server/templates/site/view.html:437
+#: peeringdb_server/templates/site/view_organization_assets.html:79
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: peeringdb_server/templates/site/org_manage_keys.html:79
+#: peeringdb_server/templates/site/profile-api-keys.html:37
+#: peeringdb_server/templates/site/profile-api-keys.html:81
+#: peeringdb_server/templates/site/view_organization_assets.html:99
 msgid "Revoke"
 msgstr "Revogar"
 
+#: peeringdb_server/templates/site/org_manage_keys.html:94
+#: peeringdb_server/templates/site/profile-api-keys.html:59
 msgid "Add Key"
 msgstr "Adicionar chave"
 
+#: peeringdb_server/templates/site/org_manage_oauth.html:6
 msgid "Application"
 msgstr "Afiliações"
 
+#: peeringdb_server/templates/site/partnerships.html:13
 msgid "Partners"
 msgstr "Parceiros"
 
+#: peeringdb_server/templates/site/password-reset.html:15
 msgid "We've sent instructions to your email address, provided it is in our system. You have 30 minutes to complete the process."
 msgstr "Enviamos instruções para o seu endereço de e-mail, desde que esteja em nosso sistema. Você tem 30 minutos para concluir o processo."
 
+#: peeringdb_server/templates/site/password-reset.html:24
+#: peeringdb_server/templates/site/password-reset.html:55
 msgid "Reset Password"
 msgstr "Redefinir senha"
 
+#: peeringdb_server/templates/site/password-reset.html:33
 msgid "The password for your account"
 msgstr "A senha para a sua conta"
 
+#: peeringdb_server/templates/site/password-reset.html:33
 msgid "has been reset, proceed to the"
 msgstr "foi redefinido, prossiga para o"
 
+#: peeringdb_server/templates/site/password-reset.html:33
 msgid "login page"
 msgstr "página de login"
 
+#: peeringdb_server/templates/site/password-reset.html:42
+#: peeringdb_server/templates/site/profile-change-email.html:53
+#: peeringdb_server/templates/site/profile-change-password.html:18
+#: peeringdb_server/templates/site/profile-change-username.html:10
+#: peeringdb_server/templates/site/profile-close-account.html:18
+#: peeringdb_server/templates/site/register.html:43
+#: peeringdb_server/templates/two_factor/_wizard_forms.html:31
 msgid "Password"
 msgstr "Senha"
 
+#: peeringdb_server/templates/site/password-reset.html:49
 msgid "Verify Password"
 msgstr "Verifique a senha"
 
+#: peeringdb_server/templates/site/password-reset.html:61
 msgid "The security token you provided is invalid, please"
 msgstr "O token de segurança que você forneceu é inválido, por favor"
 
+#: peeringdb_server/templates/site/password-reset.html:61
 msgid "try again"
 msgstr "tente novamente"
 
+#: peeringdb_server/templates/site/password-reset.html:63
 msgid "The password reset process has expired, please"
 msgstr "O processo de redefinição de senha expirou, por favor"
 
+#: peeringdb_server/templates/site/password-reset.html:63
+#: peeringdb_server/views.py:1156
 msgid "initiate again"
 msgstr "iniciar novamente"
 
+#: peeringdb_server/templates/site/profile-2fa.html:3
+#: peeringdb_server/templates/two_factor/profile/profile.html:7
 msgid "Account Security"
 msgstr "Segurança da conta"
 
+#: peeringdb_server/templates/site/profile-2fa.html:5
 msgid "Manage Two-Factor Authentication"
 msgstr "Gerenciar autenticação de dois fatores"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:5
 msgid "Affiliate with organization"
 msgstr "Afilie-se à organização"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:13
 #, python-format
 msgid "Your affiliation with %(ar_name)s is pending approval."
 msgstr "Sua afiliação com %(ar_name)s está com aprovação pendente."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:25
 #, python-format
 msgid "Your affiliation with %(ar_name)s is being reviewed by the PeeringDB administrative staff."
 msgstr "Sua afiliação com %(ar_name)s está sendo revisada pela equipe administrativa do PeeringDB."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:32
 #, python-format
 msgid "You have canceled your affiliation request with %(ar_name)s"
 msgstr "Você cancelou sua solicitação de afiliação com %(ar_name)s"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:36
 #, python-format
 msgid "Your affiliation with %(ar_name)s was denied"
 msgstr "Sua afiliação com %(ar_name)s foi negada"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:39
 msgid "The organization requires you to have a confirmed email address at one of the following domains"
 msgstr "A organização exige que você tenha um endereço de e-mail confirmado em um dos seguintes domínios"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:51
 #, python-format
 msgid "Your affiliation with %(ar_name)s was approved"
 msgstr "Sua afiliação com %(ar_name)s foi aprovada"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:59
 msgid "To affiliate with an existing organization, please enter the ASN or organization name below."
 msgstr "Para se afiliar a uma organização existente, digite o ASN ou o nome da organização abaixo."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:63
 msgid "To register a new network organization, please enter the ASN and organization name below."
 msgstr "Para registrar uma nova organização de rede, digite o ASN e o nome da organização abaixo."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:67
 msgid "To register a new facility or exchange organization, please enter the organization name below (ASN is optional)."
 msgstr "Para registrar uma nova instalação ou organização de intercâmbio, digite o nome da organização abaixo (ASN é opcional)."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:70
 msgid "Affiliation is your own organisation. That means you are an employee or otherwise working for the organisation. The affiliation request is sent to support@peeringdb.com if no one is affiliated to the organisation yet. Otherwise, the admins are contacted. Only affiliate once per organisation. If you don't get an answer within a couple of days, please contact support@peeringdb.com."
 msgstr "A afiliação é a sua própria organização. Isso significa que você é um funcionário ou trabalha para a organização. A solicitação de afiliação é enviada para support@peeringdb.com se ninguém ainda estiver afiliado à organização. Caso contrário, os administradores são contatados. Só se afilie uma vez por organização. Se você não obtiver uma resposta em alguns dias, entre em contato com support@peeringdb.com."
 
+#: peeringdb_server/templates/site/profile-affiliate.html:89
 msgid "Affiliate"
 msgstr "Afiliado"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:92
+#: peeringdb_server/templates/site/view_organization_tools.html:478
 msgid "In case the RiR entry cannot be retrieved for your ASN, please contact"
 msgstr "Caso a entrada RiR não possa ser recuperada para o seu ASN, entre em contato"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:93
 msgid "for assistance"
 msgstr "para assistência"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:97
 msgid "Existing affiliations"
 msgstr "Afiliações existentes"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:100
 msgid "Your affiliation with"
 msgstr "Sua afiliação com"
 
+#: peeringdb_server/templates/site/profile-affiliate.html:100
 msgid "has been approved"
 msgstr "foi aprovado"
 
+#: peeringdb_server/templates/site/profile-api-keys.html:3
+#: peeringdb_server/templates/site/view_organization_tools.html:57
 msgid "API Keys"
 msgstr "Chaves de API"
 
+#: peeringdb_server/templates/site/profile-api-keys.html:6
 msgid "API Keys allow you to authenticate a client without providing your username and password."
 msgstr "Chaves de API permitem que você autentique um cliente sem fornecer seu nome de usuário e senha."
 
+#: peeringdb_server/templates/site/profile-api-keys.html:34
 msgid "read-only"
 msgstr "somente leitura"
 
+#: peeringdb_server/templates/site/profile-api-keys.html:47
 msgid "You are creating an API Key for a superuser account. Such API keys cannot be made read only and will always have full access. Proceed with caution."
 msgstr "Você está criando uma chave de API para uma conta de superusuário. Essas chaves de API não podem se tornar somente leitura e sempre terão acesso total. Prossiga com cuidado."
 
+#: peeringdb_server/templates/site/profile-api-keys.html:64
 msgid "Read only"
 msgstr "Somente leitura"
 
+#: peeringdb_server/templates/site/profile-change-email.html:7
 msgid "Email addresses"
 msgstr "Endereço de e-mail"
 
+#: peeringdb_server/templates/site/profile-change-email.html:14
 msgid "Primary"
 msgstr "Primário"
 
+#: peeringdb_server/templates/site/profile-change-email.html:21
 msgid "Confirmation required"
 msgstr "Necessária confirmação"
 
+#: peeringdb_server/templates/site/profile-change-email.html:22
+#: peeringdb_server/templates/site/profile-confirm-email.html:21
 msgid "Resend confirmation email"
 msgstr "Reenviar e-mail de confirmação"
 
+#: peeringdb_server/templates/site/profile-change-email.html:30
+#: peeringdb_server/templates/site/profile-change-email.html:73
 msgid "Set as primary"
 msgstr "Definir como principal"
 
+#: peeringdb_server/templates/site/profile-change-email.html:32
+#: peeringdb_server/templates/site/profile-change-email.html:74
+#: peeringdb_server/templates/site/profile-security-keys.html:47
+#: peeringdb_server/templates/site/profile-security-keys.html:73
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:187
+#: peeringdb_server/templates/site/view_organization_assets.html:55
+#: peeringdb_server/templates/site/view_organization_tools.html:887
 msgid "Remove"
 msgstr "Remover"
 
+#: peeringdb_server/templates/site/profile-change-email.html:40
 msgid "For speedy validation, it is required that you use a work e-mail address. If you plan to register your ASN with PeeringDB, it is recommended that you use an email-address that exists in the ASN's public contact details."
 msgstr "Para validação rápida, é necessário que você use um endereço de e-mail comercial. Se você planeja registrar seu ASN no PeeringDB, é recomendável usar um endereço de e-mail existente nos detalhes de contato público do ASN."
 
+#: peeringdb_server/templates/site/profile-change-email.html:58
 msgid "Set as primary email address"
 msgstr "Definir como endereço de e-mail principal"
 
+#: peeringdb_server/templates/site/profile-change-email.html:62
 msgid "Add email address"
 msgstr "Adicionar endereço de e-mail"
 
+#: peeringdb_server/templates/site/profile-change-password.html:6
 msgid "Change password"
 msgstr "Alterar senha"
 
+#: peeringdb_server/templates/site/profile-change-password.html:7
 msgid "Password changed"
 msgstr "Senha alterada"
 
+#: peeringdb_server/templates/site/profile-change-password.html:10
 msgid "Current Password"
 msgstr "Senha atual"
 
+#: peeringdb_server/templates/site/profile-change-password.html:26
 msgid "Password Verification"
 msgstr "Verificação de senha"
 
+#: peeringdb_server/templates/site/profile-change-username.html:6
+#: peeringdb_server/templates/site/profile-change-username.html:22
 msgid "Change username"
 msgstr "Mudar nome de usuário"
 
+#: peeringdb_server/templates/site/profile-change-username.html:7
 msgid "Username changed"
 msgstr "Nome de usuário alterado"
 
+#: peeringdb_server/templates/site/profile-change-username.html:17
 msgid "New username"
 msgstr "Novo usuário"
 
+#: peeringdb_server/templates/site/profile-close-account.html:6
+#: peeringdb_server/templates/site/profile-close-account.html:23
 msgid "Close Account"
 msgstr "Fechar conta"
 
+#: peeringdb_server/templates/site/profile-close-account.html:9
 msgid "You may close your account and delete the profile data associated with it. Note that this will not delete your organizations and its entities. If you are the only member of your organization and want it to be deleted as well please do so before closing your account."
 msgstr "Você pode fechar sua conta e excluir os dados de perfil associados a ela. Observe que isso não excluirá suas organizações e suas entidades. Se você é o único membro da sua organização e deseja que ela também seja excluída, faça-o antes de encerrar sua conta."
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:5
 msgid "You have confirmed your email address!"
 msgstr "Você confirmou seu endereço de e-mail!"
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:9
 msgid "Attention!"
 msgstr "Atenção!"
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:11
 msgid "Please specify an email address for your account, we won't be able to proceed with verification until you do."
 msgstr "Especifique um endereço de e-mail para sua conta, não poderemos prosseguir com a verificação até que você o faça."
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:14
 msgid "Email Confirmation"
 msgstr "Confirmação de e-mail"
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:16
 msgid "Before getting access to any other features, you need to confirm your email address."
 msgstr "Antes de obter acesso a qualquer outro recurso, você precisa confirmar seu endereço de e-mail."
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:17
 msgid "We have sent you a message containing the confirmation link."
 msgstr "Enviamos uma mensagem contendo o link de confirmação."
 
+#: peeringdb_server/templates/site/profile-confirm-email.html:27
 msgid "You won't have full access until we or the organization you are affiliated with have reviewed your account. Thank you for your patience."
 msgstr "Você não terá acesso total até que nós ou a organização à qual você está afiliado tenhamos analisado sua conta. Obrigado pela sua paciência."
 
+#: peeringdb_server/templates/site/profile-pick-language.html:8
 msgid "Select language"
 msgstr "Selecione o idioma"
 
+#: peeringdb_server/templates/site/profile-pick-language.html:9
 msgid "Language preference saved"
 msgstr "Preferência de idioma salva"
 
+#: peeringdb_server/templates/site/profile-pick-language.html:22
 msgid "Set language preference"
 msgstr "Definir preferência de idioma"
 
+#: peeringdb_server/templates/site/profile-security-keys.html:4
 msgid "Security keys"
 msgstr "Chaves de segurança"
 
+#: peeringdb_server/templates/site/profile-security-keys.html:6
 msgid "Register your security key and use it as a 2FA method or for password-less login."
 msgstr "Registre sua chave de segurança e use-a como um método 2FA ou para login sem senha."
 
+#: peeringdb_server/templates/site/profile-security-keys.html:12
 msgid "When using a U2F security key such as <b>yubikeys</b> the initial prompt may show other device-internal keys first (such as fingerprint scanners and security pins)."
 msgstr "Ao usar uma chave de segurança U2F, como <b>yubikeys</b>, o prompt inicial pode mostrar outras chaves internas do dispositivo primeiro (como leitores de impressão digital e pinos de segurança)."
 
+#: peeringdb_server/templates/site/profile-security-keys.html:19
 msgid "If your yubikey is plugged in but does not show up in the list, <b>cancel</b> the initial prompt and a new prompt for your yubikey should appear afterwards."
 msgstr "Se o seu yubikey estiver conectado, mas não aparecer na lista, <b>cancele</b> o prompt inicial e um novo prompt para o seu yubikey deve aparecer depois."
 
+#: peeringdb_server/templates/site/profile-security-keys.html:44
 msgid "passwordless-login"
 msgstr "login sem senha"
 
+#: peeringdb_server/templates/site/profile-security-keys.html:56
 msgid "Register security key"
 msgstr "Registrar chave de segurança"
 
+#: peeringdb_server/templates/site/profile-security-keys.html:61
 msgid "Password-less login"
 msgstr "Login sem senha"
 
+#: peeringdb_server/templates/site/register.html:13
 msgid "Account Created"
 msgstr "Conta criada"
 
+#: peeringdb_server/templates/site/register.html:15
 msgid "Your account was created, but won't have full access until we have reviewed it. Thank you for your patience."
 msgstr "Sua conta foi criada, mas não terá acesso total até que a analisemos. Obrigado pela sua paciência."
 
+#: peeringdb_server/templates/site/register.html:18
 msgid "Return Home"
 msgstr "Voltar ao Início"
 
+#: peeringdb_server/templates/site/register.html:32
 msgid "Create account"
 msgstr "Criar Conta"
 
+#: peeringdb_server/templates/site/register.html:36
+#: peeringdb_server/templates/two_factor/_wizard_forms.html:25
 msgid "Username"
 msgstr "Nome de usuário"
 
+#: peeringdb_server/templates/site/register.html:50
 msgid "Confirm password"
 msgstr "Confirme sua senha"
 
+#: peeringdb_server/templates/site/register.html:57
 msgid "For speedy validation, it is required that you use a work e-mail address. If you plan to register your ASN with PeeringDB, it is recommended that you use an email-address that exists in your ASN's public contact details."
 msgstr "Para validação rápida, é necessário que você use um endereço de e-mail comercial. Se você planeja registrar seu ASN no PeeringDB, é recomendável usar um endereço de e-mail existente nos detalhes de contato público do seu ASN."
 
+#: peeringdb_server/templates/site/register.html:71
 msgid "First name"
 msgstr "Primeiro nome"
 
+#: peeringdb_server/templates/site/register.html:77
 msgid "Last name"
 msgstr "Sobrenome"
 
+#: peeringdb_server/templates/site/register.html:82
 msgid "Loading anti-spam challenge"
 msgstr "Carregando desafio anti-spam"
 
+#: peeringdb_server/templates/site/request-ownership.html:15
+#: peeringdb_server/templates/site/request-ownership.html:23
 msgid "Thank you"
 msgstr "Obrigado"
 
+#: peeringdb_server/templates/site/request-ownership.html:17
 #, python-format
 msgid "We have received your ownership request for %(o_name)s and will review it."
 msgstr "Recebemos sua solicitação de propriedade para %(o_name)s e iremos analisá-la."
 
+#: peeringdb_server/templates/site/request-ownership.html:24
 msgid "We have verified your relationship with this entity and you have successfully claimed ownership. You may view / edit"
 msgstr "Verificamos seu relacionamento com esta entidade e você reivindicou a propriedade com sucesso. Você pode visualizar /editar"
 
+#: peeringdb_server/templates/site/request-ownership.html:37
+#: peeringdb_server/templates/site/request-ownership.html:53
 msgid "Request Ownership"
 msgstr "Solicitar posse"
 
+#: peeringdb_server/templates/site/request-ownership.html:48
 msgid "Please only request ownership if you are certain that you have the rights to do so. Are you sure you wish to continue?"
 msgstr "Solicite a posseapenas se tiver certeza de que possui os direitos para fazê-lo. Tem certeza que deseja continuar?"
 
+#: peeringdb_server/templates/site/request-ownership.html:61
 msgid "Only verified users may request ownership to an organization"
 msgstr "Somente usuários verificados podem solicitar a posse de uma organização"
 
+#: peeringdb_server/templates/site/search_result.html:15
 #, python-format
 msgid ""
 "\n"
@@ -2848,493 +3529,948 @@ msgstr ""
 "    <a href=“%(feedback)s”>Clique aqui</a> para enviar comentários.\n"
 "    "
 
+#: peeringdb_server/templates/site/search_result.html:29
+#: peeringdb_server/templates/site/search_result.html:35
+#: peeringdb_server/templates/site/search_result.html:39
+#: peeringdb_server/templates/site/search_result.html:45
 msgid "Showing results for"
 msgstr "Mostrando resultados para"
 
+#: peeringdb_server/templates/site/search_result.html:29
 msgid "in"
 msgstr "em"
 
+#: peeringdb_server/templates/site/search_result.html:30
+#: peeringdb_server/templates/site/search_result.html:35
+#: peeringdb_server/templates/site/search_result.html:39
 msgid "within"
 msgstr "dentro de"
 
+#: peeringdb_server/templates/site/search_result.html:35
+#: peeringdb_server/templates/site/search_result.html:39
 msgid "near"
 msgstr "próximo"
 
+#: peeringdb_server/templates/site/search_result.html:52
 msgid "Could not resolve the location you provided: "
 msgstr "Não foi possível resolver o local que você forneceu: "
 
+#: peeringdb_server/templates/site/search_result.html:68
+#: peeringdb_server/templates/site/search_result.html:81
+#: peeringdb_server/templates/site/search_result.html:95
+#: peeringdb_server/templates/site/search_result.html:108
+#: peeringdb_server/templates/site/view.html:32
 msgid "sponsor"
 msgstr "patrocinador"
 
+#: peeringdb_server/templates/site/search_result.html:123
+#: peeringdb_server/templates/site/search_result_frame.html:25
 msgid "Suggest Exchange"
 msgstr "Sugerir Exchange"
 
+#: peeringdb_server/templates/site/search_result.html:128
+#: peeringdb_server/templates/site/search_result.html:138
+#: peeringdb_server/templates/site/search_result_frame.html:30
 msgid "Suggest Network"
 msgstr "Sugerir Rede"
 
+#: peeringdb_server/templates/site/self-object-list.html:8
 msgid "Set primary organization"
 msgstr "Definir organização principal"
 
+#: peeringdb_server/templates/site/self-object-list.html:9
 msgid "Primary organization updated"
 msgstr "Organização principal atualizada"
 
+#: peeringdb_server/templates/site/sponsorships.html:80
 msgid "Become a Sponsor"
 msgstr "Torne-se um Patrocinador"
 
+#: peeringdb_server/templates/site/tutorial_mode_banner.html:7
 msgid "This server is running in TUTORIAL MODE"
 msgstr "Este servidor está rodando em MODO TUTORIAL"
 
+#: peeringdb_server/templates/site/username-retrieve-complete.html:12
 msgid "These are the usernames associated with your email address"
 msgstr "Estes são os nomes de usuário associados ao seu endereço de e-mail"
 
+#: peeringdb_server/templates/site/username-retrieve-complete.html:21
 msgid "The secret you provided does not match the secret required to complete this process"
 msgstr "O segredo que você forneceu não corresponde ao segredo necessário para concluir este processo"
 
+#: peeringdb_server/templates/site/username-retrieve-complete.html:23
 msgid "Note"
 msgstr "Nota"
 
+#: peeringdb_server/templates/site/username-retrieve-complete.html:23
 msgid "You should complete the process in the same browser that you originally initiated it in."
 msgstr "Você deve concluir o processo no mesmo navegador em que o iniciou originalmente."
 
+#: peeringdb_server/templates/site/username-retrieve-complete.html:25
 msgid "Please re-initiate it"
 msgstr "Por favor reinicie"
 
+#: peeringdb_server/templates/site/username-retrieve.html:14
 msgid "This form allows you to retrieve the usernames associated with your email address."
 msgstr "Este formulário permite que você recupere os nomes de usuário associados ao seu endereço de e-mail."
 
+#: peeringdb_server/templates/site/username-retrieve.html:17
 msgid "We've sent instructions to your email address, provided it is in our system."
 msgstr "Enviamos instruções para o seu endereço de e-mail, desde que esteja em nosso sistema."
 
+#: peeringdb_server/templates/site/username-retrieve.html:26
 msgid "Retrieve username(s)"
 msgstr "Recuperar nome(s) de usuário"
 
+#: peeringdb_server/templates/site/verification_banner.html:8
 msgid "Some of your organizations request that you confirm your email address. Your access to them has been restricted until you do so."
 msgstr "Algumas de suas organizações solicitam que você confirme seu endereço de e-mail. Seu acesso a eles será restrito até que você o faça."
 
+#: peeringdb_server/templates/site/verification_banner.html:14
 #, python-format
 msgid "%(org_name)s requests confirmation of %(email)s"
 msgstr "%(org_name)s solicita confirmação de %(email)s"
 
+#: peeringdb_server/templates/site/verification_banner.html:19
 msgid "Please confirm your email addresses "
 msgstr "Por favor, confirme seus endereços de e-mail "
 
+#: peeringdb_server/templates/site/verification_banner.html:22
 msgid "Your user account has not been affiliated with any Organization yet, and will have limited access to some of the data (such as non-public network contact information)."
 msgstr "Sua conta de usuário ainda não foi afiliada a nenhuma organização e terá acesso limitado a alguns dos dados (como informações de contato de rede não públicas)."
 
+#: peeringdb_server/templates/site/verification_banner.html:27
 msgid "Please take the time to confirm your email address and request affiliation"
 msgstr "Reserve um tempo para confirmar seu endereço de e-mail e solicitar a afiliação"
 
+#: peeringdb_server/templates/site/verification_banner.html:30
 msgid "You may request affiliation to an Organization or ASN"
 msgstr "Você pode solicitar afiliação a uma Organização ou ASN"
 
+#: peeringdb_server/templates/site/verify.html:21
 msgid "Manage OAuth Applications"
 msgstr "Gerenciar aplicativos OAuth"
 
+#: peeringdb_server/templates/site/view.html:40
 msgid "Add at least 2 facilities for your campus to be visible."
 msgstr "Adicione pelo menos 2 PoPs para que seu campus fique visível."
 
+#: peeringdb_server/templates/site/view.html:42
 msgid "Pending Review"
 msgstr "Revisão pendente"
 
+#: peeringdb_server/templates/site/view.html:78
 msgid "Some of the data on this page is incomplete, please update the fields marked with"
 msgstr "Alguns dos dados desta página estão incompletos, atualize os campos marcados com"
 
+#: peeringdb_server/templates/site/view.html:80
 msgid "to improve data quality"
 msgstr "para melhorar a qualidade dos dados"
 
+#: peeringdb_server/templates/site/view.html:91
+#: peeringdb_server/templates/site/view_organization_tools.html:97
 msgid "Suggested Address:"
 msgstr "Endereço sugerido:"
 
+#: peeringdb_server/templates/site/view.html:99
+#: peeringdb_server/templates/site/view_facility_bottom.html:100
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:394
+#: peeringdb_server/templates/site/view_organization_tools.html:104
 msgid "Accept"
 msgstr "Aceito"
 
+#: peeringdb_server/templates/site/view.html:118
+msgid "Social Media"
+msgstr "Mídia social"
+
+#: peeringdb_server/templates/site/view.html:372
+#: peeringdb_server/templates/site/view.html:377
 msgid "Geocode data for this entity could not obtained at this point. This is done automatically upon address field changes."
 msgstr "Os dados de geocódigo para esta entidade não puderam ser obtidos neste momento. Isso é feito automaticamente após alterações no campo de endereço."
 
+#: peeringdb_server/templates/site/view_campus_side.html:16
+#: peeringdb_server/templates/site/view_carrier_side.html:16
+#: peeringdb_server/templates/site/view_exchange_bottom.html:94
+#: peeringdb_server/templates/site/view_exchange_side.html:12
+#: peeringdb_server/templates/site/view_facility_bottom.html:12
+#: peeringdb_server/templates/site/view_facility_bottom.html:65
+#: peeringdb_server/templates/site/view_facility_side.html:11
+#: peeringdb_server/templates/site/view_network_side.html:19
+#: peeringdb_server/templates/site/view_network_side.html:243
+#: peeringdb_server/templates/site/view_organization_side.html:20
+#: peeringdb_server/templates/site/view_organization_side.html:89
+#: peeringdb_server/templates/site/view_organization_side.html:156
+#: peeringdb_server/templates/site/view_organization_side.html:224
+#: peeringdb_server/templates/site/view_organization_side.html:282
 msgid "Filter"
 msgstr "Filtro"
 
+#: peeringdb_server/templates/site/view_campus_side.html:21
+#: peeringdb_server/templates/site/view_campus_side.html:38
+#: peeringdb_server/templates/site/view_campus_side.html:84
+#: peeringdb_server/templates/site/view_carrier_side.html:21
+#: peeringdb_server/templates/site/view_carrier_side.html:38
+#: peeringdb_server/templates/site/view_carrier_side.html:83
+#: peeringdb_server/templates/site/view_exchange_bottom.html:99
+#: peeringdb_server/templates/site/view_exchange_bottom.html:116
+#: peeringdb_server/templates/site/view_exchange_bottom.html:156
+#: peeringdb_server/templates/site/view_network_side.html:248
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_network_side.html:318
+msgid "Facility"
+msgstr "PoP"
+
+#: peeringdb_server/templates/site/view_campus_side.html:37
+#: peeringdb_server/templates/site/view_carrier_side.html:37
+#: peeringdb_server/templates/site/view_exchange_bottom.html:115
+#: peeringdb_server/templates/site/view_exchange_side.html:36
+#: peeringdb_server/templates/site/view_facility_bottom.html:30
+#: peeringdb_server/templates/site/view_facility_bottom.html:79
+#: peeringdb_server/templates/site/view_facility_side.html:26
+#: peeringdb_server/templates/site/view_network_side.html:45
+#: peeringdb_server/templates/site/view_network_side.html:263
+#: peeringdb_server/templates/site/view_organization_side.html:39
+#: peeringdb_server/templates/site/view_organization_side.html:107
+#: peeringdb_server/templates/site/view_organization_side.html:175
+#: peeringdb_server/templates/site/view_organization_side.html:239
+#: peeringdb_server/templates/site/view_organization_side.html:297
 msgid "No filter matches."
 msgstr "Nenhum filtro corresponde."
 
+#: peeringdb_server/templates/site/view_campus_side.html:38
+#: peeringdb_server/templates/site/view_carrier_side.html:38
+#: peeringdb_server/templates/site/view_exchange_bottom.html:116
+#: peeringdb_server/templates/site/view_exchange_side.html:39
+#: peeringdb_server/templates/site/view_facility_bottom.html:31
+#: peeringdb_server/templates/site/view_facility_bottom.html:80
+#: peeringdb_server/templates/site/view_facility_side.html:27
+#: peeringdb_server/templates/site/view_network_side.html:46
+#: peeringdb_server/templates/site/view_network_side.html:264
+#: peeringdb_server/templates/site/view_organization_side.html:40
+#: peeringdb_server/templates/site/view_organization_side.html:108
+#: peeringdb_server/templates/site/view_organization_side.html:176
+#: peeringdb_server/templates/site/view_organization_side.html:240
+#: peeringdb_server/templates/site/view_organization_side.html:298
 msgid "You may filter by"
 msgstr "Você pode filtrar por"
 
+#: peeringdb_server/templates/site/view_campus_side.html:45
 msgid "Facility link"
 msgstr "Link do PoP"
 
+#: peeringdb_server/templates/site/view_campus_side.html:52
+#: peeringdb_server/templates/site/view_facility_bottom.html:90
 msgid "Remove this carrier from your facility."
 msgstr "Remova esta operadora de seu PoP."
 
+#: peeringdb_server/templates/site/view_campus_side.html:97
+#: peeringdb_server/templates/site/view_carrier_side.html:95
+#: peeringdb_server/templates/site/view_exchange_bottom.html:168
+#: peeringdb_server/templates/site/view_network_side.html:330
+#: peeringdb_server/templates/site/view_organization_tools.html:9
 msgid "Add Facility"
 msgstr "Adicionar PoP"
 
+#: peeringdb_server/templates/site/view_carrier_side.html:45
+#: peeringdb_server/templates/site/view_exchange_bottom.html:121
 msgid "Exchange - Facility link"
 msgstr "Exchange - Link do PoP"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:11
 msgid "Prefixes"
 msgstr "Prefixos"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:15
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: peeringdb_server/templates/site/view_exchange_bottom.html:29
 msgid "IXLAN Prefix"
 msgstr "Prefixos IXLAN"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:71
 msgid "Add Prefix"
 msgstr "Adicionar Prefixo"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:91
 msgid "Local Facilities"
 msgstr "PoP local"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:185
+#: peeringdb_server/templates/site/view_network_bottom.html:223
+#: peeringdb_server/views.py:2325
 msgid "IX-F Import Preview"
 msgstr "Visualização de importação IX-F"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:188
 msgid "The actual import will run once per day at 00:00Z - use this to preview the changes that will be done"
 msgstr "A importação real será executada uma vez por dia às 00:00Z - use isso para visualizar as alterações que serão feitas"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:193
+#: peeringdb_server/templates/site/view_network_bottom.html:232
+#: peeringdb_server/templates/site/view_network_bottom.html:282
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:253
 msgid "Changes"
 msgstr "Mudanças"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:198
+#: peeringdb_server/templates/site/view_network_bottom.html:237
+#: peeringdb_server/templates/site/view_network_bottom.html:287
 msgid "Errors"
 msgstr "Erros"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:209
+#: peeringdb_server/templates/site/view_network_bottom.html:248
+#: peeringdb_server/templates/site/view_network_bottom.html:298
 msgid "speed"
 msgstr "velocidade"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:210
+#: peeringdb_server/templates/site/view_network_bottom.html:249
+#: peeringdb_server/templates/site/view_network_bottom.html:299
 msgid "routeserver"
 msgstr "servidor de rota"
 
+#: peeringdb_server/templates/site/view_exchange_bottom.html:215
+#: peeringdb_server/templates/site/view_network_bottom.html:254
 msgid "Sometimes we encounter some errors when parsing ix-f data, these will usually affect the import, you can view any of those errors below"
 msgstr "Às vezes encontramos alguns erros ao analisar dados ix-f, eles geralmente afetam a importação, você pode ver qualquer um desses erros abaixo"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:9
 msgid "Peers at this Exchange Point"
 msgstr "Peers neste Exchange"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:17
+#: peeringdb_server/templates/site/view_facility_side.html:16
+#: peeringdb_server/templates/site/view_facility_side.html:27
 msgid "Peer Name"
 msgstr "Nome do peer"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:18
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:111
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:113
+#: peeringdb_server/templates/site/view_network_side.html:25
+#: peeringdb_server/templates/site/view_network_side.html:169
+msgid "IPv4"
+msgstr "IPv4"
+
+#: peeringdb_server/templates/site/view_exchange_side.html:23
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:118
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:120
+#: peeringdb_server/templates/site/view_network_side.html:29
+#: peeringdb_server/templates/site/view_network_side.html:178
+#: peeringdb_server/templates/site/view_organization_tools.html:399
+#: peeringdb_server/templates/site/view_organization_tools.html:578
+#: peeringdb_server/templates/site/view_suggest_ix.html:111
+#: peeringdb_server/templates/site/view_suggest_net.html:124
+#: peeringdb_server/views.py:2616
+msgid "IPv6"
+msgstr "IPv6"
+
+#: peeringdb_server/templates/site/view_exchange_side.html:26
+#: peeringdb_server/templates/site/view_exchange_side.html:41
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:91
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:127
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:341
+#: peeringdb_server/templates/site/view_network_side.html:32
+#: peeringdb_server/templates/site/view_network_side.html:46
 msgid "Speed"
 msgstr "Velocidade"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:29
+#: peeringdb_server/templates/site/view_exchange_side.html:40
+msgid "Policy"
+msgstr "Política"
+
+#: peeringdb_server/templates/site/view_exchange_side.html:40
+#: peeringdb_server/templates/site/view_facility_bottom.html:17
+#: peeringdb_server/templates/site/view_facility_bottom.html:31
+#: peeringdb_server/templates/site/view_network_side.html:24
+#: peeringdb_server/templates/site/view_network_side.html:46
+#: peeringdb_server/templates/site/view_network_side.html:158
+#: peeringdb_server/templates/site/view_organization_side.html:181
 msgid "Exchange"
 msgstr "Exchange"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:41
 msgid "IP"
 msgstr "IP"
 
+#: peeringdb_server/templates/site/view_exchange_side.html:57
+#: peeringdb_server/templates/site/view_network_assets.html:18
+#: peeringdb_server/templates/site/view_network_side.html:67
 msgid "Not operational"
 msgstr "Não operacional"
 
+#: peeringdb_server/templates/site/view_facility_bottom.html:20
+#: peeringdb_server/templates/site/view_facility_bottom.html:31
+#: peeringdb_server/views.py:1496 peeringdb_server/views.py:1705
+#: peeringdb_server/views.py:1924 peeringdb_server/views.py:2023
+#: peeringdb_server/views.py:2150 peeringdb_server/views.py:2510
+msgid "Long Name"
+msgstr "Nome Completo"
+
+#: peeringdb_server/templates/site/view_facility_bottom.html:70
+msgid "Carrier"
+msgstr "Operadora"
+
+#: peeringdb_server/templates/site/view_facility_bottom.html:100
+#: peeringdb_server/templates/site/view_facility_bottom.html:101
 msgid "This carrier wants to list its presence at this facility."
 msgstr "Esta operadora deseja listar sua presença nesta instalação."
 
+#: peeringdb_server/templates/site/view_facility_bottom.html:100
 msgid "Click to accept this request"
 msgstr "Clique para aceitar esta solicitação"
 
+#: peeringdb_server/templates/site/view_facility_bottom.html:101
 msgid "Click to reject this request"
 msgstr "Clique para rejeitar esta solicitação"
 
+#: peeringdb_server/templates/site/view_facility_bottom.html:101
 msgid "Reject"
 msgstr "Rejeitar"
 
+#: peeringdb_server/templates/site/view_network_assets.html:37
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:137
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:363
+#: peeringdb_server/templates/site/view_network_side.html:92
+#: peeringdb_server/templates/site/view_network_side.html:207
+msgid "Operational"
+msgstr "Operacional"
+
+#: peeringdb_server/templates/site/view_network_bottom.html:14
+#: peeringdb_server/templates/site/view_network_bottom.html:202
+#: peeringdb_server/views.py:2210
 msgid "Contact Information"
 msgstr "Informações de contato"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:21
+#: peeringdb_server/templates/site/view_network_bottom.html:208
 msgid "Some of this network's contacts are hidden because they are only visible to authenticated users and you are currently not logged in."
 msgstr "Alguns dos contatos desta rede estão ocultos porque são visíveis apenas para usuários autenticados e você não está conectado no momento."
 
+#: peeringdb_server/templates/site/view_network_bottom.html:23
+#: peeringdb_server/templates/site/view_network_bottom.html:210
 msgid "Some of this network's contacts are hidden because your user account is not affiliated with any organization."
 msgstr "Alguns dos contatos desta rede estão ocultos porque sua conta de usuário não é afiliada a nenhuma organização."
 
+#: peeringdb_server/templates/site/view_network_bottom.html:32
+#: peeringdb_server/templates/site/view_network_bottom.html:139
+msgid "Role"
+msgstr "Função"
+
+#: peeringdb_server/templates/site/view_network_bottom.html:40
 msgid "Visiblity"
 msgstr "Visibilidade"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:50
+#: peeringdb_server/templates/site/view_network_bottom.html:168
+msgid "Phone"
+msgstr "Telefone"
+
+#: peeringdb_server/templates/site/view_network_bottom.html:54
 msgid "E-Mail"
 msgstr "E-mail"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:177
+msgid "Visibility"
+msgstr "Visibilidade"
+
+#: peeringdb_server/templates/site/view_network_bottom.html:190
 msgid "Add Contact"
 msgstr "Adicionar contato"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:226
 msgid "Below is a preview of changes that will be done to your network during the next IX-F data import. The actual import will run once per day at 00:00Z"
 msgstr "Abaixo está uma prévia das alterações que serão feitas em sua rede durante a próxima importação de dados IX-F. A importação real será executada uma vez por dia às 00:00Z"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:227
 msgid "We use locally cached IX-F data to generate this preview - if you are expecting changes to an exchange's IX-F data please give it some time to be reflected here."
 msgstr "Usamos dados IX-F armazenados localmente em cache para gerar essa visualização - se você espera alterações nos dados IX-F de uma bolsa, aguarde algum tempo para que sejam refletidas aqui."
 
+#: peeringdb_server/templates/site/view_network_bottom.html:244
+#: peeringdb_server/templates/site/view_network_bottom.html:294
 msgid "action"
 msgstr "ação"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:245
+#: peeringdb_server/templates/site/view_network_bottom.html:295
 msgid "exchange"
 msgstr "exchange"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:262
+#: peeringdb_server/templates/site/view_network_bottom.html:313
 msgid "Close"
 msgstr "Fechar"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:274
 msgid "IX-F Import Postmortem"
 msgstr "IX-F Importação post mortem"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:277
 msgid "Below is a log of changes done to you network -&gt; exchange connections as a result of IX-F data imports. Note that this does not contain any adjustments done by staff to rollback such changes, but should be viewed as a raw log of actions taken by the IX-F data import."
 msgstr "Abaixo está um registro das alterações feitas em sua rede -&gt; conexões de troca como resultado de importações de dados IX-F. Observe que isso não contém nenhum ajuste feito pela equipe para reverter essas alterações, mas deve ser visto como um log bruto de ações realizadas pela importação de dados IX-F."
 
+#: peeringdb_server/templates/site/view_network_bottom.html:311
 msgid "Showing most recent"
 msgstr "Mostrando mais recente"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:311
 msgid "changes"
 msgstr "mudanças"
 
+#: peeringdb_server/templates/site/view_network_bottom.html:312
 msgid "Refresh"
 msgstr "Atualizar"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:10
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:41
 msgid "Some exchanges suggest updates to your entries in their peering list."
 msgstr "Alguns exchanges sugerem atualizações para suas entradas em sua lista de peering."
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:16
 msgid "Review suggestions"
 msgstr "Sugestões de revisão"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:24
 msgid "You have dismissed some suggestions that are still available."
 msgstr "Você descartou algumas sugestões que ainda estão disponíveis."
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:25
 msgid "Will restore any suggestions you have previously dismissed"
 msgstr "Irá restaurar quaisquer sugestões que você tenha descartado anteriormente"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:25
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:414
 msgid "Reset Suggestions"
 msgstr "Redefinir sugestões"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:45
 msgid "Expand each exchange below to review, apply or dismiss those suggestions"
 msgstr "Expanda cada exchange abaixo para revisar, aplicar ou descartar essas sugestões"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:75
 msgid "Their PeeringDB entry"
 msgstr "Sua entrada PeeringDB"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:78
 msgid "Automatically update and remove all suggested entries"
 msgstr "Atualize e remova automaticamente todas as entradas sugeridas"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:78
 msgid "Auto-resolve"
 msgstr "Resolução automática"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:80
 msgid "Automatically add all suggested entries"
 msgstr "Adicionar automaticamente todas as entradas sugeridas"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:80
 msgid "Auto-add"
 msgstr "Adicionar automaticamente"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:94
+#: peeringdb_server/templates/site/view_organization_tools.html:902
 msgid "Options"
 msgstr "Opções"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:158
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:218
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:384
 msgid "Hide this suggestion until the exchange updates it."
 msgstr "Oculte esta sugestão até que a troca a atualize."
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:159
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:219
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:385
 msgid "Dismiss"
 msgstr "Liberar"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:167
 msgid "Add this entry to public peering exchange points"
 msgstr "Adicione esta entrada aos exchanges de peerings púlicos"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:227
 msgid "Remove this entry from your public peering exchange points list"
 msgstr "Remova esta entrada da sua lista de exchanges de peerings púlicos"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:228
 #, python-format
 msgid "Remove the entry %(ixf_id)s for %(ix_name)s from your public peering exchange points list?"
 msgstr "Remover a entrada %(ixf_id)s para %(ix_name)s da sua lista de exchanges de peerings púlicos?"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:324
 msgid "Set IPv6 address"
 msgstr "Definir endereço IPv6"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:326
 msgid "Clear IPv6 address"
 msgstr "Limpar endereço IPv6"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:332
 msgid "Set IPv4 address"
 msgstr "Definir endereço IPv4"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:334
 msgid "Clear IPv4 address"
 msgstr "Limpar endereço IPv4"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:393
 msgid "Update this entry in your public peering exchange points list. You will also need to save the network record to persist these changes after accepting them."
 msgstr "Atualize esta entrada em sua lista de exchanges de peering públicos. Você também precisará salvar o registro de rede para manter essas alterações depois de aceitá-las."
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:414
 msgid "Will restore any active suggestions from this exchange that have been dismissed by the network"
 msgstr "Restaurará todas as sugestões ativas deste exchange que foram descartadas pela rede"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:418
 msgid "Will add all suggested entries"
 msgstr "Adicionará todas as entradas sugeridas"
 
+#: peeringdb_server/templates/site/view_network_ixf_suggestions.html:418
 msgid "Auto Add"
 msgstr "Adicionar automaticamente"
 
+#: peeringdb_server/templates/site/view_network_side.html:16
+msgid "Public Peering Exchange Points"
+msgstr "Internet Exchange sde Peering Público"
+
+#: peeringdb_server/templates/site/view_network_side.html:51
 msgid "Network - Exchange link"
 msgstr "Rede - Link do Exchange"
 
+#: peeringdb_server/templates/site/view_network_side.html:75
+#: peeringdb_server/templates/site/view_network_side.html:286
 msgid "Entry needs to be moved to correct network"
 msgstr "A entrada precisa ser movida para a rede correta"
 
+#: peeringdb_server/templates/site/view_network_side.html:187
+msgid "Speed (mbit/sec)"
+msgstr "Velocidade (mbit/seg)"
+
+#: peeringdb_server/templates/site/view_network_side.html:218
 msgid "Add Exchange Point"
 msgstr "Adicionar Exchange"
 
+#: peeringdb_server/templates/site/view_network_side.html:240
 msgid "Interconnection Facilities"
 msgstr "PoPs de Interconexão"
 
+#: peeringdb_server/templates/site/view_organization_assets.html:52
 msgid "member"
 msgstr "membro"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:3
 msgid "Manage"
 msgstr "Gerenciar"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:16
 msgid "Add Network"
 msgstr "Adicionar rede"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:23
 msgid "Add Exchange"
 msgstr "Adicionar Exchange"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:31
 msgid "Add Carrier"
 msgstr "Adicionar Operadora"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:39
 msgid "Add Campus"
 msgstr "Adicionar Campus"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:47
+msgid "Users"
+msgstr "Usuários/Utilizadores"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:52
 msgid "Permissions"
 msgstr "Permissões"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:62
 msgid "API Key Permissions"
 msgstr "Permissões de chave de API"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:67
 msgid "OAuth"
 msgstr "OAuth"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:72
 msgid "Delete Organization"
 msgstr "Excluir organização"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:135
+#: peeringdb_server/templates/site/view_suggest_fac.html:56
+#: peeringdb_server/views.py:1509 peeringdb_server/views.py:1717
+msgid "Address 1"
+msgstr "Endereço 1"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:144
+#: peeringdb_server/templates/site/view_suggest_fac.html:65
+#: peeringdb_server/views.py:1515 peeringdb_server/views.py:1722
+msgid "Address 2"
+msgstr "Endereço 2"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:169
+#: peeringdb_server/templates/site/view_suggest_fac.html:90
+msgid "Zip-Code"
+msgstr "Código postal"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:191
+#: peeringdb_server/templates/site/view_suggest_fac.html:112
+#: peeringdb_server/views.py:1764
+msgid "CLLI Code"
+msgstr "Código CLLI"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:207
+#: peeringdb_server/templates/site/view_organization_tools.html:592
+#: peeringdb_server/templates/site/view_suggest_fac.html:129
+#: peeringdb_server/templates/site/view_suggest_ix.html:125
 msgid "Technical E-mail"
 msgstr "E-mail Técnico"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:219
+#: peeringdb_server/templates/site/view_organization_tools.html:605
+#: peeringdb_server/templates/site/view_suggest_fac.html:140
+#: peeringdb_server/templates/site/view_suggest_ix.html:132
+#: peeringdb_server/views.py:1802 peeringdb_server/views.py:2232
+msgid "Technical Phone"
+msgstr "Telefone Técnico"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:228
+#: peeringdb_server/templates/site/view_organization_tools.html:636
+#: peeringdb_server/templates/site/view_suggest_fac.html:149
 msgid "Sales E-mail"
 msgstr "E-mail de Vendas"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:240
+#: peeringdb_server/templates/site/view_organization_tools.html:648
+#: peeringdb_server/templates/site/view_suggest_fac.html:161
+#: peeringdb_server/views.py:1815 peeringdb_server/views.py:2258
+msgid "Sales Phone"
+msgstr "Telefone de Vendas"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:250
+#: peeringdb_server/templates/site/view_organization_tools.html:454
+#: peeringdb_server/templates/site/view_organization_tools.html:668
+#: peeringdb_server/views.py:1851 peeringdb_server/views.py:2265
+#: peeringdb_server/views.py:2755
 msgid "Health Check"
 msgstr "Verificação de saúde"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:366
+#: peeringdb_server/templates/site/view_suggest_net.html:91
+#: peeringdb_server/views.py:2588
+msgid "Traffic Ratios"
+msgstr "Proporções de tráfego"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:406
+#: peeringdb_server/templates/site/view_suggest_net.html:131
 msgid "Policy URL"
 msgstr "URL da Política"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:425
+#: peeringdb_server/templates/site/view_suggest_net.html:150
+#: peeringdb_server/views.py:2735
+msgid "Multiple Locations"
+msgstr "Localidades Múltiplas"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:435
+#: peeringdb_server/templates/site/view_suggest_net.html:160
+#: peeringdb_server/views.py:2742
+msgid "Ratio Requirement"
+msgstr "Requisito de Proporção"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:443
+#: peeringdb_server/templates/site/view_suggest_net.html:168
+#: peeringdb_server/views.py:2750
+msgid "Contract Requirement"
+msgstr "Requisito de contrato"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:466
 msgid "Only use this if you own the network"
 msgstr "Só use isso se você for o proprietário da rede"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:467
 msgid "Add a new Network to your Organization."
 msgstr "Adicione uma nova rede à sua organização."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:468
 msgid "We will attempt to automatically verify your relationship to the network by checking for your email address in the ASN's RiR entry."
 msgstr "Tentaremos verificar automaticamente sua relação com a rede verificando seu endereço de e-mail na entrada RiR do ASN."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:470
 msgid "In case of verification failure the network will need to be approved by PeeringDB staff before it will appear in the search results or the API listings."
 msgstr "Em caso de falha na verificação, a rede precisará ser aprovada pela equipe do PeeringDB antes de aparecer nos resultados da pesquisa ou nas listagens da API."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:474
 msgid "Submit Network"
 msgstr "Enviar Rede"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:480
 msgid "for assistance with the creation of your network in PeeringDB."
 msgstr "para obter assistência com a criação de sua rede no PeeringDB."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:585
+#: peeringdb_server/templates/site/view_suggest_ix.html:118
+#: peeringdb_server/views.py:2220
+msgid "Traffic Stats Website"
+msgstr "Website de Estatísticas de Tráfego"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:615
+#: peeringdb_server/templates/site/view_suggest_ix.html:139
 msgid "Policy E-mail"
 msgstr "Email da Política"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:627
+#: peeringdb_server/templates/site/view_suggest_ix.html:146
+#: peeringdb_server/views.py:2245
+msgid "Policy Phone"
+msgstr "Telefone da Política"
+
+#: peeringdb_server/templates/site/view_organization_tools.html:661
+#: peeringdb_server/templates/site/view_suggest_ix.html:158
 msgid "IPv4 or IPv6 prefix"
 msgstr "Prefixo IPv4 ou IPv6"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:773
 msgid "Users requesting affiliation"
 msgstr "Usuários solicitando afiliação"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:788
 msgid "Confirmed"
 msgstr "Confirmado"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:790
 msgid "Date"
 msgstr "Data"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:811
+#: peeringdb_server/templates/site/view_organization_tools.html:873
 msgid "Email address requirements not met"
 msgstr "Requisitos de endereço de e-mail não atendidos"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:828
 msgid "Currently no users requesting affiliation with"
 msgstr "Atualmente não há usuários solicitando afiliação com"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:838
 msgid "Users in Organization"
 msgstr "Usuários na organização"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:854
 msgid "Group"
 msgstr "Grupo"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:912
 msgid "Restrict user email addresses to these domains"
 msgstr "Restrinja os endereços de e-mail dos usuários a esses domínios"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:919
 msgid "Require users to periodically re-confirm their email address: "
 msgstr "Exija que os usuários reconfirmem periodicamente seu endereço de e-mail: "
 
+#: peeringdb_server/templates/site/view_organization_tools.html:928
 msgid "Update Options"
 msgstr "Opções de atualização"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:943
 msgid "Here you can grant permissions to regular members of your organization. Administrative users are not listed here as they have access to everything by default."
 msgstr "Aqui você pode conceder permissões a membros regulares de sua organização. Os usuários administrativos não estão listados aqui, pois têm acesso a tudo por padrão."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:948
 msgid "Additionally, entities that are pending review cannot be permissioned out to users, and will not appear in the entity list."
 msgstr "Além disso, as entidades com revisão pendente não podem ser autorizadas aos usuários e não aparecerão na lista de entidades."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:1074
 #, python-format
 msgid "%(name)s cannot be deleted."
 msgstr "%(name)s não pode ser deletado."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:1083
 msgid "Remove this organization from PeeringDB."
 msgstr "Remova esta organização do PeeringDB."
 
+#: peeringdb_server/templates/site/view_organization_tools.html:1094
 msgid "Delete organization?"
 msgstr "Delete organization?"
 
+#: peeringdb_server/templates/site/view_organization_tools.html:1094
 #, python-format
 msgid "Delete %(name)s"
 msgstr "Excluir %(name)s"
 
+#: peeringdb_server/templates/site/view_suggest_fac.html:14
+#: peeringdb_server/templates/site/view_suggest_ix.html:14
+#: peeringdb_server/templates/site/view_suggest_net.html:14
 msgid "Thank you for your suggestion."
 msgstr "Obrigado pela sua sugestão."
 
+#: peeringdb_server/templates/site/view_suggest_fac.html:19
 msgid "Suggest another facility"
 msgstr "Sugira outro PoP"
 
+#: peeringdb_server/templates/site/view_suggest_fac.html:182
+#: peeringdb_server/templates/site/view_suggest_ix.html:178
+#: peeringdb_server/templates/site/view_suggest_net.html:191
 msgid "Only verified users may suggest entities."
 msgstr "Somente usuários verificados podem sugerir entidades."
 
+#: peeringdb_server/templates/site/view_suggest_ix.html:19
 msgid "Suggest another exchange"
 msgstr "Sugerir outro exchange"
 
+#: peeringdb_server/templates/site/view_suggest_net.html:19
 msgid "Suggest another network"
 msgstr "Sugerir outra rede"
 
+#: peeringdb_server/templates/two_factor/_base.html:32
 msgid "For <strong>password-less</strong> authentication leave the password field empty and make sure your registered U2F FIDO security key is available / connected."
 msgstr "Para autenticação <strong>sem senha</strong>, deixe o campo de senha vazio e certifique-se de que sua chave de segurança U2F FIDO registrada esteja disponível/conectada."
 
+#: peeringdb_server/templates/two_factor/_wizard_forms.html:35
 msgid "I forgot my password .."
 msgstr "Esqueci a minha senha .."
 
+#: peeringdb_server/templates/two_factor/_wizard_forms.html:36
 msgid "I forgot my username .."
 msgstr "Eu esqueci meu nome de usuário .."
 
+#: peeringdb_server/templates/two_factor/_wizard_forms.html:51
 msgid "Token"
 msgstr "Token"
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:5
 msgid "Backup Tokens"
 msgstr "Backup Tokens"
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:6
 msgid "Backup tokens can be used when your primary authentication method isn't available. The backup tokens below can be used for login verification. If you've used up all your backup tokens, you can generate a new set of backup tokens. Only the backup tokens shown below will be valid."
 msgstr "Os tokens de backup podem ser usados quando seu método de autenticação principal não está disponível. Os tokens de backup abaixo podem ser usados para verificação de login. Se você tiver usado todos os seus tokens de backup, poderá gerar um novo conjunto de tokens de backup. Somente os tokens de backup mostrados abaixo serão válidos."
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:14
 msgid "Print these tokens and keep them somewhere safe."
 msgstr "Imprima esses tokens e guarde-os em algum lugar seguro."
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:16
 msgid "You don't have any backup codes yet."
 msgstr "Você ainda não tem códigos backup."
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:21
 msgid "Back to Account Security"
 msgstr "Voltar para a segurança da conta"
 
+#: peeringdb_server/templates/two_factor/core/backup_tokens.html:22
 msgid "Generate Tokens"
 msgstr "Gerar tokens"
 
+#: peeringdb_server/templates/two_factor/core/login.html:10
 msgid "Enter your credentials."
 msgstr "Digite suas credenciais."
 
+#: peeringdb_server/templates/two_factor/core/login.html:13
 msgid ""
 "We are calling your phone right now, please enter the\n"
 "        digits you hear."
@@ -3342,6 +4478,7 @@ msgstr ""
 "Estamos ligando para o seu telefone agora, por favor digite o\n"
 "        dígitos que você ouve."
 
+#: peeringdb_server/templates/two_factor/core/login.html:16
 msgid ""
 "We sent you a text message, please enter the tokens we\n"
 "        sent."
@@ -3349,9 +4486,11 @@ msgstr ""
 "Enviamos uma mensagem de texto, por favor, insira os tokens que\n"
 "        enviado."
 
+#: peeringdb_server/templates/two_factor/core/login.html:19
 msgid "We sent you an email, please enter the one time password we sent."
 msgstr "Enviamos um e-mail para você, digite a senha única que enviamos."
 
+#: peeringdb_server/templates/two_factor/core/login.html:21
 msgid ""
 "Please enter the tokens generated by your token\n"
 "        generator."
@@ -3359,9 +4498,11 @@ msgstr ""
 "Insira os tokens gerados pelo seu token\n"
 "        gerador."
 
+#: peeringdb_server/templates/two_factor/core/login.html:26
 msgid "Requesting U2F security key authentication"
 msgstr "Solicitando autenticação de chave de segurança U2F"
 
+#: peeringdb_server/templates/two_factor/core/login.html:29
 msgid ""
 "Use this form for entering backup tokens for logging in.\n"
 "      These tokens have been generated for you to print and keep safe. Please\n"
@@ -3371,341 +4512,876 @@ msgstr ""
 "      Esses tokens foram gerados para você imprimir e manter em segurança. Por favor\n"
 "      insira um desses tokens de backup para fazer login em sua conta."
 
+#: peeringdb_server/templates/two_factor/core/login.html:41
 msgid "Or, alternatively, you can request a one time password via one of your recovery options:"
 msgstr "Ou, alternativamente, você pode solicitar uma senha única por meio de uma de suas opções de recuperação:"
 
+#: peeringdb_server/templates/two_factor/core/login.html:51
 msgid "As a last resort, you can use a backup token:"
 msgstr "Como último recurso, você pode usar um token de backup:"
 
+#: peeringdb_server/templates/two_factor/core/login.html:54
 msgid "Use Backup Token"
 msgstr "Usar token de backup"
 
+#: peeringdb_server/templates/two_factor/core/setup.html:5
 msgid "Enable Two-Factor Authentication"
 msgstr "Ativar autenticação de dois fatores"
 
+#: peeringdb_server/templates/two_factor/core/setup.html:7
 msgid "You are about to take your account security to the next level. Follow the steps in this wizard to enable two-factor authentication."
 msgstr "Você está prestes a levar a segurança da sua conta para o próximo nível. Siga as etapas deste assistente para habilitar a autenticação de dois fatores."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:11
 msgid "Please select which authentication method you would like to use."
 msgstr "Por favor, selecione qual método de autenticação você gostaria de usar."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:14
 msgid "To start using a token generator, please use your smartphone to scan the QR code below. For example, use Google Authenticator. Then, enter the token generated by the app."
 msgstr "Para começar a usar um gerador de token, use seu smartphone para escanear o código QR abaixo. Por exemplo, use o Google Authenticator. Em seguida, insira o token gerado pelo aplicativo."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:19
 msgid "Or manually enter the setup key to your Authenticator app."
 msgstr "Ou insira manualmente a chave de configuração no seu aplicativo Authenticator."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:22
 msgid "Please enter the phone number you wish to receive the text messages on. This number will be validated in the next step."
 msgstr "Por favor, digite o número de telefone no qual você deseja receber as mensagens de texto. Este número será validado na próxima etapa."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:26
 msgid "Please enter the phone number you wish to be called on. This number will be validated in the next step."
 msgstr "Por favor, digite o número de telefone para o qual deseja ser chamado. Este número será validado na próxima etapa."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:31
 msgid "We are calling your phone right now, please enter the digits you hear."
 msgstr "Estamos ligando para o seu telefone agora, digite os dígitos que ouvir."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:34
 msgid "We sent you a text message, please enter the tokens we sent."
 msgstr "Enviamos uma mensagem de texto para você, digite os tokens que enviamos."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:38
 msgid "We've encountered an issue with the selected authentication method. Please go back and verify that you entered your information correctly, try again, or use a different authentication method instead. If the issue persists, contact the site administrator."
 msgstr "Encontramos um problema com o método de autenticação selecionado. Volte e verifique se inseriu suas informações corretamente, tente novamente ou use um método de autenticação diferente. Se o problema persistir, entre em contato com o administrador do site."
 
+#: peeringdb_server/templates/two_factor/core/setup.html:45
 msgid "To identify and verify your YubiKey, please insert a token in the field below. Your YubiKey will be linked to your account."
 msgstr "Para identificar e verificar sua YubiKey, insira um token no campo abaixo. Sua YubiKey será vinculada à sua conta."
 
+#: peeringdb_server/templates/two_factor/profile/profile.html:9
 msgid "Add a TOPT method to your two-factor authentication"
 msgstr "Adicione um método TOPT à sua autenticação de dois fatores"
 
+#: peeringdb_server/templates/two_factor/profile/profile.html:11
 msgid "Add TOTP Authentication"
 msgstr "Adicionar autenticação TOTP"
 
+#: peeringdb_server/templatetags/two_factor_ext.py:16
 msgid "Email one time password"
 msgstr "Senha de uso único por e-mail"
 
+#: peeringdb_server/templatetags/two_factor_ext.py:19
 msgid "U2F security key"
 msgstr "Chave de segurança U2F"
 
+#: peeringdb_server/templatetags/util.py:109
 msgid "Your email address does not match the domain information we have on file for this organization."
 msgstr "Seu endereço de e-mail não corresponde às informações de domínio que temos arquivadas para esta organização."
 
+#: peeringdb_server/templatetags/util.py:169
 msgid "seconds ago"
 msgstr "segundos atrás"
 
+#: peeringdb_server/templatetags/util.py:171
 msgid "minutes ago"
 msgstr "minutos atrás"
 
+#: peeringdb_server/templatetags/util.py:173
 msgid "hours ago"
 msgstr "horas atrás"
 
+#: peeringdb_server/templatetags/util.py:175
 msgid "days ago"
 msgstr "dias atrás"
 
+#: peeringdb_server/util.py:70
 msgid "{soc.get(\"service\", dismiss)}"
 msgstr "{soc.get(“service”, dismiss)}"
 
+#: peeringdb_server/validators.py:34
 msgid "Invalid format"
 msgstr "Formato Inválido"
 
+#: peeringdb_server/validators.py:50
 msgid "Private contacts are no longer supported."
 msgstr "Contatos privados não são mais suportados."
 
+#: peeringdb_server/validators.py:79
 msgid "Not a valid phone number (E.164)"
 msgstr "Não é um número de telefone válido (E.164)"
 
+#: peeringdb_server/validators.py:101
 msgid "Input required"
 msgstr "Entrada necessária"
 
+#: peeringdb_server/validators.py:124
 msgid "Invalid prefix: {}"
 msgstr "Prefixo inválido: {}"
 
+#: peeringdb_server/validators.py:142
 msgid "Address space invalid: {}"
 msgstr "Espaço de endereço inválido: {}"
 
+#: peeringdb_server/validators.py:153
 msgid "Maximum allowed prefix length is {}"
 msgstr "O tamanho máximo permitido do prefixo é {}"
 
+#: peeringdb_server/validators.py:157
 msgid "Minimum allowed prefix length is {}"
 msgstr "O tamanho mínimo permitido do prefixo é {}"
 
+#: peeringdb_server/validators.py:166 peeringdb_server/validators.py:187
 msgid "Negative value not allowed"
 msgstr "Valor negativo não permitido"
 
+#: peeringdb_server/validators.py:174 peeringdb_server/validators.py:195
 msgid "Maximum value allowed {}"
 msgstr "Valor máximo permitido {}"
 
+#: peeringdb_server/validators.py:224
 msgid "Prefix overlaps with {}'s prefix: {}"
 msgstr "O prefixo se sobrepõe ao prefixo de {}: {}"
 
+#: peeringdb_server/validators.py:250
 msgid "IRR AS-SET value must be string type"
 msgstr "O valor IRR AS-SET deve ser do tipo string"
 
+#: peeringdb_server/validators.py:283
 msgid "Invalid formatting: {} - should be AS-SET, ASx, AS-SET@SOURCE or SOURCE::AS-SET"
 msgstr "Formatação inválida: {} - deve ser AS-SET, ASx, AS-SET@SOURCE ou SOURCE::AS-SET"
 
+#: peeringdb_server/validators.py:289
 msgid "Unknown IRR source: {}"
 msgstr "Fonte IRR desconhecida: {}"
 
+#: peeringdb_server/validators.py:300
 msgid "Maximum AS-SET hierarchy depth: {}"
 msgstr "Profundidade máxima da hierarquia AS-SET: {}"
 
+#: peeringdb_server/validators.py:320
 msgid "Invalid formatting: {} - should be RS-SET, AS-SET or AS123"
 msgstr "Formatação inválida: {} - deve ser RS-SET, AS-SET ou AS123"
 
+#: peeringdb_server/validators.py:326
 msgid "All parts of an hierarchical name have to be of the same type"
 msgstr "Todas as partes de um nome hierárquico devem ser do mesmo tipo"
 
+#: peeringdb_server/validators.py:331
 msgid "At least one component must be an actual set name"
 msgstr "Pelo menos um componente deve ser um nome de conjunto real"
 
+#: peeringdb_server/validators.py:366
 msgid "Needs to be 'True', 'False', 1 or 0"
 msgstr "Precisa ser ‘True’, ‘Falso’, 1 ou 0"
 
+#: peeringdb_server/validators.py:392
 msgid "Invalid setting! Acceptable value is a number followed by one of the following: minute, hour, seconds, day, week, month, year. eg (10/minute, 1/hour, 5/day, 1/week, 1/month, 1/year)"
 msgstr "Configuração inválida! O valor aceitável é um número seguido por um dos seguintes: minute, hour, seconds, day, week, month, year. eg (10/minute, 1/hour, 5/day, 1/week, 1/month, 1/year)"
 
+#: peeringdb_server/validators.py:416
 msgid "Malformed social media data."
 msgstr "Dados de mídia social malformados."
 
+#: peeringdb_server/validators.py:419
 msgid "Duplicate social media services set."
 msgstr "Conjunto de serviços de mídia social duplicados."
 
+#: peeringdb_server/validators.py:424
 msgid "Service should not be empty!"
 msgstr "O serviço não deve estar vazio!"
 
+#: peeringdb_server/validators.py:426
 msgid "Identifier should not be empty!"
 msgstr "O identificador não deve estar vazio!"
 
+#: peeringdb_server/validators.py:433
 #, python-brace-format
 msgid "Invalid {service} URL!"
 msgstr "URL de {service} inválido!"
 
+#: peeringdb_server/validators.py:441
 #, python-brace-format
 msgid "Invalid {service} username!"
 msgstr "Nome de usuário {service} inválido!"
 
+#: peeringdb_server/validators.py:445
 msgid "Invalid service!"
 msgstr "Serviço inválido!"
 
+#: peeringdb_server/validators.py:448
 msgid "Invalid identifier!"
 msgstr "Identificador inválido!"
 
+#: peeringdb_server/views.py:326 peeringdb_server/views.py:355
 msgid "Please wait a bit before requesting ownership again."
 msgstr "Aguarde um pouco antes de solicitar a posse novamente."
 
+#: peeringdb_server/views.py:333
 msgid "Invalid organization"
 msgstr "Organização inválida"
 
+#: peeringdb_server/views.py:339 peeringdb_server/views.py:372
 #, python-format
 msgid "Organization '%(org_name)s' is already under ownership"
 msgstr "A organização ‘%(org_name)s’ já está sob propriedade"
 
+#: peeringdb_server/views.py:365
 msgid "Organization does not exist"
 msgstr "A organização não existe"
 
+#: peeringdb_server/views.py:386
 msgid "You already have an ownership request pending for this organization"
 msgstr "Você já tem uma solicitação de propriedade pendente para esta organização"
 
+#: peeringdb_server/views.py:397 peeringdb_server/views.py:459
 msgid "You have too many affiliation requests pending, please wait for them to be resolved before opening more."
 msgstr "Você tem muitos pedidos de afiliação pendentes, por favor, espere que eles sejam resolvidos antes de abrir mais."
 
+#: peeringdb_server/views.py:449
 msgid "Please wait a bit before requesting affiliation again."
 msgstr "Aguarde um pouco antes de solicitar a afiliação novamente."
 
+#: peeringdb_server/views.py:475 peeringdb_server/views.py:476
 msgid "Either ASN or Organization required"
 msgstr "ASN ou organização necessária"
 
+#: peeringdb_server/views.py:500
 msgid "Unable to affiliate as this organization has been deleted. Please reach out to PeeringDB support if you wish to resolve this."
 msgstr "Não é possível se afiliar porque esta organização foi excluída. Entre em contato com o suporte do PeeringDB se desejar resolver isso."
 
+#: peeringdb_server/views.py:510
 msgid "You already requested affiliation to this ASN/org"
 msgstr "Você já solicitou afiliação a esta ASN/org"
 
+#: peeringdb_server/views.py:569
 msgid "Please wait a bit before trying to resend the confirmation email again"
 msgstr "Aguarde um pouco antes de tentar reenviar o e-mail de confirmação novamente"
 
+#: peeringdb_server/views.py:577
 msgid "We have resent your confirmation email"
 msgstr "Reenviamos seu e-mail de confirmação"
 
+#: peeringdb_server/views.py:603
 msgid "Malformed Language Preference"
 msgstr "Preferência de idioma malformado"
 
+#: peeringdb_server/views.py:664
 msgid "Register on behalf of one of your organizations"
 msgstr "Registre-se em nome de uma de suas organizações"
 
+#: peeringdb_server/views.py:824
 msgid "Please wait a bit before requesting another email change"
 msgstr "Aguarde um pouco antes de solicitar outra alteração de e-mail"
 
+#: peeringdb_server/views.py:836
 msgid "Invalid password. Please try again."
 msgstr "Senha inválida. Por favor, tente novamente."
 
+#: peeringdb_server/views.py:845
 msgid "E-mail already exists in our system"
 msgstr "O e-mail já existe em seu sistema"
 
+#: peeringdb_server/views.py:854
 msgid "You may have a maximum of {} email addresses"
 msgstr "Você pode ter no máximo {} endereços de e-mail"
 
+#: peeringdb_server/views.py:919
 msgid "Cannot remove primary email"
 msgstr "Não é possível remover o e-mail principal"
 
+#: peeringdb_server/views.py:963
 msgid "Email address not found"
 msgstr "Endereço de email não encontrado"
 
+#: peeringdb_server/views.py:986 peeringdb_server/views.py:1014
 msgid "Wrong password"
 msgstr "Senha incorreta"
 
+#: peeringdb_server/views.py:1060
 msgid "Please wait a bit before requesting your usernames again."
 msgstr "Aguarde um pouco antes de solicitar seus nomes de usuário novamente."
 
+#: peeringdb_server/views.py:1154
 msgid "Invalid Security Token"
 msgstr "Token de segurança inválido"
 
+#: peeringdb_server/views.py:1156
 msgid "Password Reset Process has expired, please"
 msgstr "O processo de redefinição de senha expirou, por favor"
 
+#: peeringdb_server/views.py:1205
 msgid "Please log out of your current session before trying to register. Notice, multiple accounts are no longer needed."
 msgstr "Saia da sua sessão atual antes de tentar se registrar. Observe que várias contas não são mais necessárias."
 
+#: peeringdb_server/views.py:1231
 msgid "This email address has already been used"
 msgstr "Este endereço de e-mail já foi utilizado"
 
+#: peeringdb_server/views.py:1243
 msgid "Username cannot start with 'apikey'"
 msgstr "O nome de usuário não pode começar com ‘apikey’"
 
+#: peeringdb_server/views.py:1286
 msgid "Incorrect password"
 msgstr "Senha incorreta"
 
+#: peeringdb_server/views.py:1490 peeringdb_server/views.py:1699
+#: peeringdb_server/views.py:1919 peeringdb_server/views.py:2018
+#: peeringdb_server/views.py:2145 peeringdb_server/views.py:2504
+msgid "Also Known As"
+msgstr "Também conhecido como"
+
+#: peeringdb_server/views.py:1518 peeringdb_server/views.py:1725
+msgid "Floor"
+msgstr "Andar"
+
+#: peeringdb_server/views.py:1519 peeringdb_server/views.py:1726
+msgid "Suite"
+msgstr "Sala"
+
+#: peeringdb_server/views.py:1522 peeringdb_server/views.py:1729
 msgid "Location"
 msgstr "Localização"
 
+#: peeringdb_server/views.py:1531 peeringdb_server/views.py:1737
+#: peeringdb_server/views.py:2044
 msgid "Country Code"
 msgstr "Código do país"
 
+#: peeringdb_server/views.py:1537 peeringdb_server/views.py:1758
 msgid "Geocode"
 msgstr "Geocódigo"
 
+#: peeringdb_server/views.py:1549 peeringdb_server/views.py:1780
+#: peeringdb_server/views.py:1945 peeringdb_server/views.py:2056
+#: peeringdb_server/views.py:2197 peeringdb_server/views.py:2655
+msgid "Notes"
+msgstr "Notas"
+
+#: peeringdb_server/views.py:1550 peeringdb_server/views.py:1781
+#: peeringdb_server/views.py:1946 peeringdb_server/views.py:2057
+#: peeringdb_server/views.py:2198 peeringdb_server/views.py:2656
 msgid "Markdown enabled"
 msgstr "Markdown habilitado"
 
+#: peeringdb_server/views.py:1556
 msgid "Logo"
 msgstr "Logotipo"
 
+#: peeringdb_server/views.py:1559
 msgid "Max size: {}kb"
 msgstr "Tamanho máximo: {}kb"
 
+#: peeringdb_server/views.py:1713 peeringdb_server/views.py:1930
+#: peeringdb_server/views.py:2035 peeringdb_server/views.py:2214
+#: peeringdb_server/views.py:2516
+msgid "Company Website"
+msgstr "Website da Empresa"
+
+#: peeringdb_server/views.py:1754
 msgid "Facility is part of a campus"
 msgstr "PoP faz parte de um campus"
 
+#: peeringdb_server/views.py:1796 peeringdb_server/views.py:2226
+msgid "Technical Email"
+msgstr "Email técnico"
+
+#: peeringdb_server/views.py:1809 peeringdb_server/views.py:2252
+msgid "Sales Email"
+msgstr "E-mail de Vendas"
+
+#: peeringdb_server/views.py:1931 peeringdb_server/views.py:2036
 msgid "Company Website Override"
 msgstr "Substituição do site da empresa"
 
+#: peeringdb_server/views.py:1933 peeringdb_server/views.py:2038
 msgid "If this field is set, it will be displayed on this record. If not, we will display the website from the organization record this is tied to"
 msgstr "Se este campo estiver definido, ele será exibido neste registro. Caso contrário, exibiremos o site do registro da organização ao qual está vinculado"
 
+#: peeringdb_server/views.py:2239
+msgid "Policy Email"
+msgstr "Email da Política"
+
+#: peeringdb_server/views.py:2283
 msgid "LAN"
 msgstr "LAN"
 
+#: peeringdb_server/views.py:2290
 msgid "Payload MTU"
 msgstr "Payload MTU"
 
+#: peeringdb_server/views.py:2295
 msgid "Enable IX-F Import"
 msgstr "Ativar importação IX-F"
 
+#: peeringdb_server/views.py:2306
+msgid "IX-F Member Export URL"
+msgstr "URL de Exportação de Membro IXF"
+
+#: peeringdb_server/views.py:2320
+msgid "IX-F Member Export URL Visibility"
+msgstr "Visibilidade da URL de Exportação de Membro IXF"
+
+#: peeringdb_server/views.py:2333
 msgid "Request import"
 msgstr "Solicitar importação"
 
+#: peeringdb_server/views.py:2475
 msgid "Disable notifications"
 msgstr "Desativar notificações"
 
+#: peeringdb_server/views.py:2482
 msgid "Enable notifications"
 msgstr "Habilitar notificações"
 
+#: peeringdb_server/views.py:2538
+msgid "Route Server URL"
+msgstr "URL do Servidor de rotas"
+
+#: peeringdb_server/views.py:2545
+msgid "Looking Glass URL"
+msgstr "URL do Looking Glass"
+
+#: peeringdb_server/views.py:2560
+msgid "IPv4 Prefixes"
+msgstr "Prefixos IPv4"
+
+#: peeringdb_server/views.py:2569
+msgid "IPv6 Prefixes"
+msgstr "Prefixos IPv6"
+
+#: peeringdb_server/views.py:2602
 msgid "Protocols Supported"
 msgstr "Protocolos suportados"
 
+#: peeringdb_server/views.py:2621
+msgid "Never via route servers"
+msgstr "Nunca via Servidores de rota"
+
+#: peeringdb_server/views.py:2638
 msgid "Public Peering Info Updated"
 msgstr "Informações de peering público atualizadas"
 
+#: peeringdb_server/views.py:2644
 msgid "Peering Facility Info Updated"
 msgstr "Informações sobre o peering PoP atualizadas"
 
+#: peeringdb_server/views.py:2650
 msgid "Contact Info Updated"
 msgstr "Informações de contato atualizadas"
 
+#: peeringdb_server/views.py:2663
 msgid "RIR Status"
 msgstr "Status do RIR"
 
+#: peeringdb_server/views.py:2670
 msgid "RIR Status Updated"
 msgstr "Status do RIR atualizado"
 
+#: peeringdb_server/views.py:2682
 msgid "PeeringDB Configuration"
 msgstr "Configuração do PeeringDB"
 
+#: peeringdb_server/views.py:2686
 msgid "Allow IXP Update"
 msgstr "Permitir atualização IXP"
 
+#: peeringdb_server/views.py:2688
 msgid "If enabled, an IXP may manage this network's entry in their peering list"
 msgstr "Se ativado, um IXP pode gerenciar a entrada desta rede em sua lista de peering"
 
+#: peeringdb_server/views.py:2701
 msgid "Notify On IXP Update"
 msgstr "Notificar sobre atualização de IXP"
 
+#: peeringdb_server/views.py:2703
 msgid "Notify me when an IXP modifies the peering exchange points for this network"
 msgstr "Notifique-me quando um IXP modificar os pontos de troca de peering para esta rede"
 
+#: peeringdb_server/views.py:2710
 msgid "IXP Update Tools"
 msgstr "Ferramentas de Atualização IXP"
 
+#: peeringdb_server/views.py:2713
 msgid "Postmortem"
 msgstr "Pós-morte"
 
+#: peeringdb_server/views.py:2716
 msgid "Peering Policy Information"
 msgstr "Informações da política de peering"
 
+#: peeringdb_server/views.py:2719
+msgid "Peering Policy"
+msgstr "Política de Peering"
+
+#: peeringdb_server/views.py:3287
 msgid "Please wait a bit before trying to login again."
 msgstr "Aguarde um pouco antes de tentar fazer login novamente."
 
+#: peeringdb_server/views.py:3599
 msgid "Malformed Organization Preference"
 msgstr "Preferência de organização malformada"
+
+#~ msgid "Ethernet"
+#~ msgstr "Ethernet"
+
+#~ msgid "ATM"
+#~ msgstr "ATM"
+
+#~ msgid "Multiple"
+#~ msgstr "Múltiplo"
+
+#~ msgid "Abuse"
+#~ msgstr "Abuso"
+
+#~ msgid "Maintenance"
+#~ msgstr "Manutenção"
+
+#~ msgid "Technical"
+#~ msgstr "Técnico"
+
+#~ msgid "NOC"
+#~ msgstr "NOC"
+
+#~ msgid "Public Relations"
+#~ msgstr "Relações públicas"
+
+#~ msgid "Sales"
+#~ msgstr "Vendas"
+
+#~ msgid "Open"
+#~ msgstr "Aberto"
+
+#~ msgid "Selective"
+#~ msgstr "Seletivo"
+
+#~ msgid "Restrictive"
+#~ msgstr "Restritivo"
+
+#~ msgid "Not Required"
+#~ msgstr "Opcional"
+
+#~ msgid "Preferred"
+#~ msgstr "Preferido"
+
+#~ msgid "Required - US"
+#~ msgstr "Obrigatória - US"
+
+#~ msgid "Required - EU"
+#~ msgstr "Obrigatório - UE"
+
+#~ msgid "Required - International"
+#~ msgstr "Obrigatório - internacional"
+
+#~ msgid "Private Only"
+#~ msgstr "Apenas Privado"
+
+#~ msgid "Required"
+#~ msgstr "Obrigatório"
+
+#~ msgid "Heavy Outbound"
+#~ msgstr "Outbound Pesado"
+
+#~ msgid "Mostly Outbound"
+#~ msgstr "Principalmente de Saída"
+
+#~ msgid "Balanced"
+#~ msgstr "Balanceado"
+
+#~ msgid "Mostly Inbound"
+#~ msgstr "Principalmente Inound"
+
+#~ msgid "Heavy Inbound"
+#~ msgstr "Inbound Pesado"
+
+#~ msgid "North America"
+#~ msgstr "América do Norte"
+
+#~ msgid "Asia Pacific"
+#~ msgstr "Ásia-Pacífico"
+
+#~ msgid "Europe"
+#~ msgstr "Europa"
+
+#~ msgid "South America"
+#~ msgstr "América do Sul"
+
+#~ msgid "Africa"
+#~ msgstr "África"
+
+#~ msgid "Australia"
+#~ msgstr "Austrália"
+
+#~ msgid "Middle East"
+#~ msgstr "Oriente Médio"
+
+#~ msgid "Regional"
+#~ msgstr "Regional"
+
+#~ msgid "Global"
+#~ msgstr "Global"
+
+#~ msgid "0-20Mbps"
+#~ msgstr "0-20Mbps"
+
+#~ msgid "20-100Mbps"
+#~ msgstr "20-100Mbps"
+
+#~ msgid "100-1000Mbps"
+#~ msgstr "100-1000Mbps"
+
+#~ msgid "1-5Gbps"
+#~ msgstr "1-5Gbps"
+
+#~ msgid "5-10Gbps"
+#~ msgstr "5-10Gbps"
+
+#~ msgid "10-20Gbps"
+#~ msgstr "10-20Gbps"
+
+#~ msgid "20-50Gbps"
+#~ msgstr "20-50Gbps"
+
+#~ msgid "50-100Gbps"
+#~ msgstr "50-100Gbps"
+
+#~ msgid "100-200Gbps"
+#~ msgstr "100-200Gbps"
+
+#~ msgid "200-300Gbps"
+#~ msgstr "200-300Gbps"
+
+#~ msgid "300-500Gbps"
+#~ msgstr "300-500Gbps"
+
+#~ msgid "500-1000Gbps"
+#~ msgstr "500-1000Gbps"
+
+#~ msgid "1-5Tbps"
+#~ msgstr "1-5Tbps"
+
+#~ msgid "5-10Tbps"
+#~ msgstr "5-10Tbps"
+
+#~ msgid "10-20Tbps"
+#~ msgstr "10-20Tbps"
+
+#~ msgid "20-50Tbps"
+#~ msgstr "20-50Tbps"
+
+#~ msgid "50-100Tbps"
+#~ msgstr "50-100Tbps"
+
+#~ msgid "100+Tbps"
+#~ msgstr "100+Tbps"
+
+#~ msgid "NSP"
+#~ msgstr "Fornecedor de Serviços de Rede"
+
+#~ msgid "Content"
+#~ msgstr "Conteúdo"
+
+#~ msgid "Cable/DSL/ISP"
+#~ msgstr "Cabo / DSL / ISP"
+
+#~ msgid "Enterprise"
+#~ msgstr "Corporativo"
+
+#~ msgid "Educational/Research"
+#~ msgstr "Educacional/Investigação"
+
+#~ msgid "Non-Profit"
+#~ msgstr "Sem fins lucrativos"
+
+#~ msgid "Route Server"
+#~ msgstr "Servidor de rotas"
+
+#~ msgid "Network Services"
+#~ msgstr "Serviços de rede"
+
+#~ msgid "Route Collector"
+#~ msgstr "Coletor de rotas"
+
+#~ msgid "Private"
+#~ msgstr "Privado"
+
+#~ msgid "Public"
+#~ msgstr "Público"
+
+#~ msgid "An E.164-formatted phone number starts with a +, followed by the country code, then the national phone number (dropping the leading 0 in most countries), without spaces or dashes between the groups of digits"
+#~ msgstr "Um número de telefone no formato E.164 começa com um +, seguido pelo código do país e, em seguida, pelo número de telefone nacional (retirando o 0 inicial na maioria dos países), sem espaços ou hífens entre os grupos de dígitos"
+
+#~ msgid "Best Effort (no SLA)"
+#~ msgstr "Melhor esforço (sem SLA)"
+
+#~ msgid "Normal Business Hours"
+#~ msgstr "Horário comercial normal"
+
+#~ msgid "24/7 Support"
+#~ msgstr "Suporte 24/7"
+
+#~ msgid "No Commercial Terms"
+#~ msgstr "Sem termos comerciais"
+
+#~ msgid "Bundled With Other Services"
+#~ msgstr "Pacote com outros serviços"
+
+#~ msgid "Non-recurring Fees Only"
+#~ msgstr "Somente taxas não recorrentes"
+
+#~ msgid "Recurring Fees"
+#~ msgstr "Taxas recorrentes"
+
+#~ msgid "Owner"
+#~ msgstr "Proprietário"
+
+#~ msgid "Lessee"
+#~ msgstr "Arrendatário"
+
+#~ msgid "48 VDC"
+#~ msgstr "48 VDC"
+
+#~ msgid "120 VAC"
+#~ msgstr "120 VAC"
+
+#~ msgid "208 VAC"
+#~ msgstr "208 VAC"
+
+#~ msgid "240 VAC"
+#~ msgstr "240 VAC"
+
+#~ msgid "480 VAC"
+#~ msgstr "480 VAC"
+
+#~ msgid "Facebook"
+#~ msgstr "Facebook"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+
+#~ msgid "Instagram"
+#~ msgstr "Instagram"
+
+#~ msgid "LinkedIn"
+#~ msgstr "LinkedIn"
+
+#~ msgid "TikTok"
+#~ msgstr "TikTok"
+
+#~ msgid "Invalid value: {}"
+#~ msgstr "Valor inválido: {}"
+
+#~ msgid "Rencode"
+#~ msgstr "Recodificar"
+
+#~ msgid "A property owner is the individual or entity that has title to the property. A lessee is a user of a property who has a lease, an agreement, with the owner of the property."
+#~ msgstr "Proprietário é o indivíduo ou entidade que possui o título da propriedade. Um arrendatário é um usuário de uma propriedade que tem um contrato de arrendamento, um acordo, com o proprietário da propriedade."
+
+#~ msgid "Two separate and distinct paths to individual substations which should maintain a separated path back to one or more utility generator stations."
+#~ msgstr "A tensão de corrente alternada disponível para os usuários da instalação, diretamente do proprietário ou fornecida separadamente pela concessionária."
+
+#~ msgid "The alternating current voltage available to users of the facility either directly from the landlord or delivered by the utility separately."
+#~ msgstr "A tensão de corrente alternada disponível para os usuários da instalação, diretamente do proprietário ou fornecida separadamente pela concessionária."
+
+#~ msgid "Status Dashboard"
+#~ msgstr "Painel de status"
+
+#~ msgid "Contact"
+#~ msgstr "Contato"
+
+#~ msgid "Contacts"
+#~ msgstr "Contatos"
+
+#~ msgid "Reference to an AS-SET or ROUTE-SET in Internet Routing Registry (IRR)"
+#~ msgstr "Referência a um AS-SET ou ROUTE-SET no Internet Routing Registry (IRR)"
+
+#~ msgid "Private notes"
+#~ msgstr "Notas Privadas"
+
+#~ msgid "Recommended maximum number of IPv4 routes/prefixes to be configured on peering sessions for this ASN"
+#~ msgstr "Número máximo recomendado de rotas/prefixos IPv4 a serem configurados em sessões de peering para este ASN"
+
+#~ msgid "Recommended maximum number of IPv6 routes/prefixes to be configured on peering sessions for this ASN"
+#~ msgstr "Número máximo recomendado de rotas/prefixos IPv6 a serem configurados em sessões de peering para este ASN"
+
+#~ msgid "Indicates if this network will announce its routes via route servers or not"
+#~ msgstr "Indica se esta rede anunciará suas rotas via servidores de rota ou não"
+
+#~ msgid "RIR status"
+#~ msgstr "RIR status"
+
+#~ msgid "RIR status updated"
+#~ msgstr "Status do RIR atualizado"
+
+#~ msgid "IX-F Network Count"
+#~ msgstr "Contagem de rede IX-F"
+
+#~ msgid "IX-F Last Import"
+#~ msgstr "Log de importação IXF"
+
+#~ msgid "Internet Exchange"
+#~ msgstr "Internet Exchange"
+
+#~ msgid "Internet Exchanges"
+#~ msgstr "Internet Exchanges"
+
+#~ msgid "Internet Exchange facility"
+#~ msgstr "Internet Exchange PoP"
+
+#~ msgid "Internet Exchange facilities"
+#~ msgstr "Internet Exchange PoPs"
+
+#~ msgid "Route Server ASN"
+#~ msgstr "ASN do Servidor de rotas"
+
+#~ msgid "ARP sponging MAC"
+#~ msgstr "ARP sponging MAC"
+
+#~ msgid "Internet Exchange LAN"
+#~ msgstr "Internet Exchange LAN"
+
+#~ msgid "Internet Exchange LANs"
+#~ msgstr "Internet Exchange LANs"
+
+#~ msgid "Internet Exchange LAN prefix"
+#~ msgstr "Internet Exchange prefixo da LAN"
+
+#~ msgid "Internet Exchange LAN prefixes"
+#~ msgstr "Internet Exchange prefixos das LANs"
+
+#~ msgid "Local ASN"
+#~ msgstr "ASN local"
+
+#~ msgid "Network Facility"
+#~ msgstr "PoP de rede"
+
+#~ msgid "Network Facilities"
+#~ msgstr "PoPs de rede"
+
+#~ msgid "RS peer"
+#~ msgstr "RS peer"
+
+#~ msgid "Public Peering Exchange Point"
+#~ msgstr "Internet Exchange de Peering Público"
+
+#~ msgid "Carrier presence at facility"
+#~ msgstr "Presença da Operadora na Instalação"
+
+#~ msgid "Carrier presences at facility"
+#~ msgstr "Presenças da Operadora na Instalação"
+
+#~ msgid "Campus Name"
+#~ msgstr "Nome do Campus"
 
 #, fuzzy
 #~| msgid "Merge Facilities"

--- a/locale/pt/LC_MESSAGES/djangojs.po
+++ b/locale/pt/LC_MESSAGES/djangojs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2023-06-14 23:19+0200\n"
+"POT-Creation-Date: 2023-06-15 11:26+0000\n"
+"PO-Revision-Date: 2023-06-15 13:29+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt\n"
@@ -17,153 +17,223 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.1\n"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:84
 msgid "Some of the fields contain invalid values - please correct and try again."
 msgstr "Alguns dos campos contêm valores inválidos - favor corrigir e tentar novamente. e tente novamente."
 
+#: peeringdb_server/static/20c/twentyc.edit.js:87
 msgid "Permission denied"
 msgstr "Permissão negada"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:89
 msgid "Bad request"
 msgstr "Solicitação inválida"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:91
 msgid "Not found"
 msgstr "Não encontrado"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:93
 msgid "File too large"
 msgstr "Arquivo muito grande"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:95
 msgid "Internal error"
 msgstr "Erro interno"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:97
 msgid "Something went wrong."
 msgstr "Ocorreu um erro."
 
+#: peeringdb_server/static/20c/twentyc.edit.js:663
+#: peeringdb_server/static/peeringdb.js:928
+#: peeringdb_server/static/peeringdb.js:2268
 msgid "The server rejected your data"
 msgstr "O servidor rejeitou seus dados"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:829
 msgid "Invalid value"
 msgstr "Valor inválido"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:833
 msgid "Input required"
 msgstr "Entrada necessária"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:920
 msgid "Needs to match password"
 msgstr "A senha deve coincidir"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:937
 msgid "Needs to be a valid email address"
 msgstr "É necessário que seja um endereço de email válido"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:966
 msgid "Needs to be a valid url"
 msgstr "É necessário que seja uma url válida"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:986
 msgid "Needs to be a number"
 msgstr "É necessário que seja um número"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:996
+#: peeringdb_server/static/peeringdb.js:2834
 msgid "Yes"
 msgstr "Sim"
 
+#: peeringdb_server/static/20c/twentyc.edit.js:996
+#: peeringdb_server/static/peeringdb.js:2835
 msgid "No"
 msgstr "Não"
 
+#: peeringdb_server/static/peeringdb.js:497
+msgid "Queued"
+msgstr "Enfileirado"
+
+#: peeringdb_server/static/peeringdb.js:503
 msgid "Please wait before requesting another import."
 msgstr "Aguarde antes de solicitar outra importação."
 
+#: peeringdb_server/static/peeringdb.js:503
 msgid "Available in: "
 msgstr "Disponível em: "
 
+#: peeringdb_server/static/peeringdb.js:503
 msgid "seconds"
 msgstr "segundos"
 
+#: peeringdb_server/static/peeringdb.js:733
+#: peeringdb_server/static/peeringdb.js:761
 msgid "Nothing to do"
 msgstr "Nada para fazer"
 
+#: peeringdb_server/static/peeringdb.js:736
 msgid "This will create the following entries"
 msgstr "Isso criará as seguintes entradas"
 
+#: peeringdb_server/static/peeringdb.js:766
 msgid "Remove these entries"
 msgstr "Remover essas entradas"
 
+#: peeringdb_server/static/peeringdb.js:772
 msgid "Update these entries"
 msgstr "Atualizar essas entradas"
 
+#: peeringdb_server/static/peeringdb.js:941
+#: peeringdb_server/static/peeringdb.js:2301
 msgid "You do not have permissions to perform this action"
 msgstr "Você não tem permissão para executar esta ação"
 
+#: peeringdb_server/static/peeringdb.js:1389
+#: peeringdb_server/static/peeringdb.js:2129
 msgid "sponsor"
 msgstr "patrocinador"
 
+#: peeringdb_server/static/peeringdb.js:1686
+#: peeringdb_server/static/peeringdb.js:1722
+#: peeringdb_server/static/peeringdb.js:1792
+#: peeringdb_server/static/peeringdb.js:1864
+#: peeringdb_server/static/peeringdb.js:2397
+#: peeringdb_server/static/peeringdb.js:3497
 msgid "Remove"
 msgstr "Remover"
 
+#: peeringdb_server/static/peeringdb.js:1696
+#: peeringdb_server/static/peeringdb.js:1732
+#: peeringdb_server/static/peeringdb.js:1802
+#: peeringdb_server/static/peeringdb.js:1874
 msgid "Canceled"
 msgstr "Cancelado"
 
+#: peeringdb_server/static/peeringdb.js:1779
 msgid "Your API key was successfully created. Write this key down some place safe. Keys cannot be recovered once  this message is exited or overwritten."
 msgstr "Sua chave de API foi criada com sucesso. Anote esta chave em algum lugar seguro. As chaves não podem ser recuperadas depois que esta mensagem for encerrada ou substituída."
 
+#: peeringdb_server/static/peeringdb.js:1837
+#: peeringdb_server/static/peeringdb.js:1923
 msgid "Revoke key"
 msgstr "Revogar chave"
 
+#: peeringdb_server/static/peeringdb.js:1955
 msgid "Add user"
 msgstr "Incluir usuário"
 
+#: peeringdb_server/static/peeringdb.js:1955
 msgid "to Organization?"
 msgstr "para a Organização?"
 
+#: peeringdb_server/static/peeringdb.js:1972
 msgid "Deny"
 msgstr "Negar"
 
+#: peeringdb_server/static/peeringdb.js:1972
 msgid "request to join the Organization?"
 msgstr "solicitar para se juntar à Organização?"
 
+#: peeringdb_server/static/peeringdb.js:2221
 msgid "Unknown request type:"
 msgstr "Tipo de pedido desconhecido:"
 
+#: peeringdb_server/static/peeringdb.js:2272
 msgid "not yet been approved"
 msgstr "ainda não foi aprovado"
 
+#: peeringdb_server/static/peeringdb.js:2273
 msgid "Parent entity pending review - please wait for it to be approved before adding entities to it"
 msgstr "Revisão pendente de entidade controladora - favor aguardar a aprovação antes de adicionar entidade"
 
+#: peeringdb_server/static/peeringdb.js:2449
 msgid "Exchange"
 msgstr "Ponto de Troca de Tráfego"
 
+#: peeringdb_server/static/peeringdb.js:2470
 msgid "Participant"
 msgstr "Participante"
 
+#: peeringdb_server/static/peeringdb.js:2493
 msgid "Facility"
 msgstr "Instalação/Infraestrutura"
 
+#: peeringdb_server/static/peeringdb.js:2509
 msgid "Campus"
 msgstr "Campus"
 
+#: peeringdb_server/static/peeringdb.js:2525
 msgid "Network Contact"
 msgstr "Contato de rede"
 
+#: peeringdb_server/static/peeringdb.js:2562
 msgid "Network - Exchange link"
 msgstr "Rede - Link do Ponto de Troca de Tráfego"
 
+#: peeringdb_server/static/peeringdb.js:2640
 msgid "Network - Facility link"
 msgstr "Rede - Link da Infraestrutura"
 
+#: peeringdb_server/static/peeringdb.js:2666
 msgid "IXLAN Prefix"
 msgstr "Prefixo IXLAN"
 
+#: peeringdb_server/static/peeringdb.js:2687
 msgid "Exchange - Facility link"
 msgstr "Ponto de Troca de Tráfego - Link da Infraestrutura"
 
+#: peeringdb_server/static/peeringdb.js:2722
 msgid "Carrier presence at Facility"
 msgstr "Presença da operadora na Infraestrutura"
 
+#: peeringdb_server/static/peeringdb.js:2937
 msgid "Click to remove"
 msgstr "Click para remover"
 
+#: peeringdb_server/static/peeringdb.js:3094
 msgid "Needs to be an integer or a speed ending in M, G, or T"
 msgstr "Precisa ser um número inteiro ou uma velocidade terminando em M, G ou T"
 
+#: peeringdb_server/static/peeringdb.js:3493
 msgid "Upload"
 msgstr "Carregar"
 
+#: peeringdb_server/static/peeringdb.js:3606
 msgid "File size too big"
 msgstr "Tamanho do arquivo muito grande"
 


### PR DESCRIPTION
Adding/fixing pt_BR translation, steps:
- Added/fixed current pt/LC_MESSAGES/django.po and pt/LC_MESSAGES/djangojs.po;
- Updated current messages following the [translation guide](https://github.com/peeringdb/peeringdb/blob/master/docs/dev/translation.md);
- Reviewed/updated/compiled new po(s), and apparently looks good.
````
(venv) /srv/www.peeringdb.com # django-admin compilemessages -i venv | grep pt
File “/srv/www.peeringdb.com/locale/pt/LC_MESSAGES/django.po” is already compiled and up to date.
File “/srv/www.peeringdb.com/locale/pt/LC_MESSAGES/djangojs.po” is already compiled and up to date.
````