### PR TITLE
fix misleading translation: s/Vertraulich/nicht angegeben/ for "Not Disclosed"

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -88,7 +88,7 @@ msgid "IPv6"
 msgstr "IPv6"
 
 msgid "Not Disclosed"
-msgstr "Vertraulich"
+msgstr "nicht angegeben"
 
 msgid "Heavy Outbound"
 msgstr "Stark ausgehend"


### PR DESCRIPTION
When something is "not disclosed" it does not mean that is confidential (a secret). It could just mean that the form field was not filled out.

See also line 4002 and 4003 in revision
https://github.com/peeringdb/translations/blob/35292d4/locale/de_DE/LC_MESSAGES/django.po#L4002